### PR TITLE
Fix the position of closing tag </li>

### DIFF
--- a/src/content/templates/default/module.php
+++ b/src/content/templates/default/module.php
@@ -74,8 +74,8 @@ function widget_sort($title){
 		</li>
 		<?php endforeach; ?>
 		</ul>
-    </li>
 	<?php endif; ?>
+	</li>
 	<?php endforeach; ?>
 	</ul>
 	</li>


### PR DESCRIPTION
This closing tag was missing, then introduced in 91de91ede36c0fa4c9ddbc5961aa0e795f7b9dbb, but to a wrong position. In this way, only a category _with_ children cats will have this tag.
The patch fixes this problem.
(Sorry about the last empty line, it was created by Github editor automatically.)
