### PR TITLE
Wrap RSS logo into <li> element

### DIFF
--- a/src/content/templates/default/side.php
+++ b/src/content/templates/default/side.php
@@ -31,8 +31,10 @@ foreach ($widgets as $val)
 }
 ?>
 <?php if (Option::get('rss_output_num')):?>
+<li style="padding-left:0;background:none;">
 <div class="rss">
 <a href="<?php echo BLOG_URL; ?>rss.php" title="RSS订阅"><img src="<?php echo TEMPLATE_URL; ?>images/rss.gif" alt="订阅Rss"/></a>
 </div>
+</li>
 <?php endif;?>
 </ul><!--end #siderbar-->


### PR DESCRIPTION
The sidebar is a <ul> element, and the RSS logo was not wrapped inside a <li> element (but a <div>). This breaks the (X)HTML standard and doesn't pass the validator.
The patch adds a <li> element while trying to keep the looking unchanged. Another way to fix it could be changing <div> to <li>.
