### PR TITLE
前台和后台的一些前端显示调整

### DIFF
--- a/admin/views/article_write.php
+++ b/admin/views/article_write.php
@@ -188,6 +188,12 @@
             imageUpload: true,
             imageFormats: ["jpg", "jpeg", "gif", "png"],
             imageUploadURL: "media.php?action=upload&editor=1",
+            onload : function() {
+                    //在大屏模式下，编辑器默认显示预览
+                    if($(window).width() > 767){
+                        this.watch();
+                    }
+            }
         });
         Editor_summary = editormd("logexcerpt", {
             width: "100%",
@@ -206,15 +212,9 @@
             flowChart: false,
             autoFocus: false,
             sequenceDiagram: false,
-            placeholder: "如果留空，则使用文章内容作为摘要...",
+            placeholder: "如果留空，则使用文章内容作为摘要..."
         });
         Editor.setToolbarAutoFixed(false);
         Editor_summary.setToolbarAutoFixed(false);
-        $("#displayToggle").bind('click', function () {
-            var editor_act = Editor_summary.toolbarHandlers;
-            $.proxy(editor_act.watch, Editor_summary)();
-            $.proxy(editor_act.clear, Editor_summary)();
-            $.proxy(editor_act.undo, Editor_summary)();
-        });
     });
 </script>

--- a/admin/views/css/css-main.css
+++ b/admin/views/css/css-main.css
@@ -1,5 +1,13 @@
 /*main.css*/
-li {list-style:none;}
+:root {
+    overflow-x: hidden
+}
+body {
+    background-color: #f8f9fc
+}
+li {
+    list-style:none
+}
 .tdcenter {
     text-align:center;
     padding-left:0;
@@ -443,4 +451,92 @@ textarea {
     cursor:pointer;
     height:15px;
     float: right;
+}
+
+@media all and (min-width: 768px){
+
+    .emlog_title {
+        padding-left: 4px;
+    }
+
+    .shadow {
+        box-shadow: 0 2px 10px 0 rgb(0 0 0 / 5%)!important;
+    }
+
+    .container, .container-fluid, .container-sm, .container-md, .container-lg, .container-xl {
+        width: auto;
+        padding-top: 80px;
+        padding-left: 218px;
+    }
+    
+    .sidebar {
+        position: fixed;
+        padding-inline: 9x;
+        z-index: 2;
+    }
+    .navbar {
+        width: 100%;
+        position: fixed;
+        z-index: 1;
+    }
+
+    .ml-md-3, .mx-md-3 {
+        margin-left: 210px!important;
+    }
+
+    .d-md-inline {
+        display: none !important;
+    }
+
+    .sidebar .nav-item .nav-link span {
+        padding-left: 1px;
+    }
+
+    .sidebar .nav-item .collapse .collapse-inner .collapse-item, .sidebar .nav-item .collapsing .collapse-inner .collapse-item {
+        white-space: break-spaces;
+    }
+
+    footer.sticky-footer {
+        background-color: unset!important;
+    }
+
+}
+
+@media all and (max-width: 767px) and (min-width: 1px) {
+    
+    /*scroll hidden*/
+    body {
+        position: absolute;
+        width: 100%;
+        overflow-x: hidden;
+    }
+
+    .sd-hidden {
+        width: 0 !important;
+    }
+
+    #content-wrapper {
+        min-height: 100vh;
+        position: absolute;
+    }
+
+    .toggle {
+        margin-left: -91px;
+    }
+
+    .sidebar .nav-item .collapse .collapse-inner .collapse-item.active, .sidebar .nav-item .collapsing .collapse-inner .collapse-item.active {
+        color: #4e73df;;
+    }
+    .sidebar .nav-item .collapse .collapse-inner .collapse-item, .sidebar .nav-item .collapsing .collapse-inner .collapse-item {
+        color: #3a3b45;
+    }
+
+    .container, .container-fluid, .container-sm, .container-md, .container-lg, .container-xl {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    .sd_menu_hd {
+        display: none;
+    }
 }

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -24,8 +24,8 @@
 </head>
 <body>
 <div id="wrapper">
-    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-        <li class="nav-item active" id="menu_home">
+    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion sd-hidden" id="accordionSidebar">
+        <li class="nav-item active emlog_title" id="menu_home">
             <a class="nav-link" href="./">EMLOG PRO <?php if (ISREG === false) : ?>未注册<?php endif; ?></a>
         </li>
         <hr class="sidebar-divider my-0">
@@ -62,8 +62,7 @@
             </li>
             <li class="nav-item" id="menu_category_view">
                 <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#menu_view" aria-expanded="true" aria-controls="menu_view">
-                    <i class="icofont-paint"></i>
-                    <span>外观</span>
+                    <i class="icofont-paint"></i><span>外观</span>
                 </a>
                 <div id="menu_view" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
                     <div class="bg-white py-2 collapse-inner rounded">
@@ -80,8 +79,7 @@
             </li>
             <li class="nav-item" id="menu_category_sys">
                 <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#menu_sys" aria-expanded="true" aria-controls="menu_sys">
-                    <i class="icofont-options"></i>
-                    <span>系统</span>
+                    <i class="icofont-options"></i><span>系统</span>
                 </a>
                 <div id="menu_sys" class="collapse" aria-labelledby="headingUtilities" data-parent="#accordionSidebar">
                     <div class="bg-white py-2 collapse-inner rounded">

--- a/admin/views/js/sb-admin-2.min.js
+++ b/admin/views/js/sb-admin-2.min.js
@@ -4,21 +4,52 @@
  * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-sb-admin-2/blob/master/LICENSE)
  */
 
-!function (s) {
-    "use strict";
-    s("#sidebarToggle, #sidebarToggleTop").on("click", function (e) {
-        s("body").toggleClass("sidebar-toggled"), s(".sidebar").toggleClass("toggled"), s(".sidebar").hasClass("toggled") && s(".sidebar .collapse").collapse("hide")
-    }), s(window).resize(function () {
-        s(window).width() < 768 && s(".sidebar .collapse").collapse("hide"), s(window).width() < 480 && !s(".sidebar").hasClass("toggled") && (s("body").addClass("sidebar-toggled"), s(".sidebar").addClass("toggled"), s(".sidebar .collapse").collapse("hide"))
-    }), s("body.fixed-nav .sidebar").on("mousewheel DOMMouseScroll wheel", function (e) {
-        if (768 < s(window).width()) {
-            var o = e.originalEvent, l = o.wheelDelta || -o.detail;
-            this.scrollTop += 30 * (l < 0 ? 1 : -1), e.preventDefault()
+$(document).ready(function(){
+
+    var sd_tog;   
+    var menu_id = ['#menu_content','#menu_sys','#menu_view']; //需要操作的所有二级菜单的id名  
+     
+    if($(window).width() < 768){ //判断在小型屏状态下
+        for(let i = 0; i < menu_id.length; i++){
+            if($(menu_id[i]).hasClass("show")){
+                $(menu_id[i]).addClass("sd_menu_hd");
+            }
         }
-    }), s(document).on("scroll", function () {
-        100 < s(this).scrollTop() ? s(".scroll-to-top").fadeIn() : s(".scroll-to-top").fadeOut()
-    }), s(document).on("click", "a.scroll-to-top", function (e) {
-        var o = s(this);
-        s("html, body").stop().animate({scrollTop: s(o.attr("href")).offset().top}, 1e3, "easeInOutExpo"), e.preventDefault()
-    })
-}(jQuery);
+        $(".sidebar").toggleClass("sd-hidden");
+    }
+    sd_tog = false;  
+    $("#menu_category_content").click(function(){ //点击打开侧边栏键
+        if($(window).width() < 768){
+            for(let i = 0; i < menu_id.length; i++){
+                if($(menu_id[0]).hasClass("sd_menu_hd")){
+                    $(menu_id[0]).removeClass("sd_menu_hd");
+                }
+            }
+        }      
+    });
+    $("#sidebarToggleTop").click(function(){     //点击侧边栏键子菜单键
+        var content_height = $("#content-wrapper").outerHeight();
+        $(".sidebar").css("min-height",content_height+"px");
+        if(!sd_tog){  //展开菜单
+            $("#content-wrapper").animate({left:'91px'},"normal","swing",
+                function(){
+                    $.each(menu_id,function(key, value){
+                        if($(value).hasClass("sd_menu_hd")){
+                            $(value).removeClass("sd_menu_hd");
+                            $(".sidebar .collapse").collapse("hide");
+                        }
+                    });
+                });
+            sd_tog = true;
+        }else{  //关闭菜单
+            $.each(menu_id,function(key, value){
+                if($(value).hasClass("sd_menu_hd")==false){
+                    $(value).addClass("sd_menu_hd");
+                }
+            });
+            $("#content-wrapper").animate({left:'0px'},"normal","swing");
+            sd_tog = false; 
+        }
+    });
+  });
+  

--- a/admin/views/page_create.php
+++ b/admin/views/page_create.php
@@ -125,8 +125,14 @@
             tex: false,
             flowChart: false,
             watch: false,
-	    htmlDecode : true,
-            sequenceDiagram: false
+            htmlDecode : true,
+            sequenceDiagram: false,
+            onload : function() {
+                    //在大屏模式下，编辑器默认显示预览
+                    if($(window).width() > 767){
+                        this.watch();
+                    }
+            }
         });
         Editor_page.setToolbarAutoFixed(false);
     });

--- a/content/templates/default/css/main.css
+++ b/content/templates/default/css/main.css
@@ -634,6 +634,7 @@ body {
 }
 
 .bloggerinfo {
+    margin-bottom: -10px;
     text-align: center
 }
 
@@ -807,7 +808,8 @@ body {
 
 .comment_lates a {
     color: #4c4c4c;
-    font-size: smaller
+    font-size: smaller;
+    padding-left: 5px
 }
 
 .comment_lates hr {
@@ -880,8 +882,7 @@ body {
 
 .log_classify_f,#navbarResponsive {
     text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap
+    overflow: hidden
 }
 
 .navbar-toggler {

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -117,15 +117,12 @@ function cancelReply(){
 	commentPlace.appendChild(response);
 }
 
-function cal_margin(links){
-		var count,menus;
-		menus=document.getElementById('dropmenus');		
-		count=menus.offsetWidth-links.offsetWidth;
-		var div_ls = document.getElementsByTagName('ul')
-		for(var i=0;i<div_ls.length;i++){
-		if(div_ls[i].getAttribute('id') == 'dropmenus'){
-			count=(count%2==0)?count:count+1;
-			div_ls[i].style.marginLeft='-'+count/2+'px';
-			}
-        }
+function cal_margin(links,dp_id){
+	var count,menus,cal_width;
+	cal_width = 85;//初始子导航的宽度(px)，可根据需要修改
+	menus=document.getElementById('dropmenus'+dp_id);		
+	count=links.offsetWidth-cal_width;
+	menus.style.width=cal_width+'px';
+	menus.style.marginLeft=count/2+'px';
 }
+

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -226,6 +226,7 @@ function blog_navi() {
     <div class="collapse navbar-collapse" id="navbarResponsive">
         <ul class="navbar-nav ml-auto top-menu">
 			<?php
+            $dp_id = 0;
 			foreach ($navi_cache as $value):
 				if ($value['pid'] != 0) {
 					continue;
@@ -245,16 +246,17 @@ function blog_navi() {
                 <li class="nav-item list-menu">
 					<?php if (!empty($value['children'])): ?>
                         <a class='nav-link' href="<?php echo $value['url']; ?>" id="nav_link"
-                           onmousemove="cal_margin(this)" <?php echo $newtab; ?>><?php echo $value['naviname']; ?> <b class="caret"></b></a>
-                        <ul class="dropdown-menus" id="dropmenus">
+                           onmousemove="cal_margin(this,<?php echo $dp_id; ?>)" <?php echo $newtab; ?>><?php echo $value['naviname']; ?> <b class="caret"></b></a>
+                        <ul class="dropdown-menus" id="dropmenus<?php echo $dp_id++; ?>">
 							<?php foreach ($value['children'] as $row) {
 								echo '<li class="nav-item list-menu"><a class="nav-link" href="' . Url::sort($row['sid']) . '">' . $row['sortname'] . '</a></li>';
 							} ?>
                         </ul>
 					<?php endif; ?>
 					<?php if (!empty($value['childnavi'])) : ?>
-                        <a class='nav-link' href="<?php echo $value['url']; ?>" <?php echo $newtab; ?>><?php echo $value['naviname']; ?> <b class="caret"></b></a>
-                        <ul class="dropdown-menus">
+                        <a class='nav-link' href="<?php echo $value['url']; ?>" id="nav_link"
+                           onmousemove="cal_margin(this,<?php echo $dp_id; ?>)" <?php echo $newtab; ?>><?php echo $value['naviname']; ?> <b class="caret"></b></a>
+                        <ul class="dropdown-menus" id="dropmenus<?php echo $dp_id++; ?>">
 							<?php foreach ($value['childnavi'] as $row) {
 								$newtab = $row['newtab'] == 'y' ? 'target="_blank"' : '';
 								echo '<li class="nav-item list-menu"><a class="nav-link" href="' . $row['url'] . "\" $newtab >" . $row['naviname'] . '</a></li>';


### PR DESCRIPTION
### 前台
-  个人资料下面的空白略减一些
-  最新评论的评论文本略向右移
-  配合js优化了导航的下拉框
-  添加了$dp_id,用来表示下拉框的编号，以便js操作更准确。
- 简化了计算导航下拉框写法。也避免了一些错误。也可自定义宽度了。
### 后台
- 重写了后台的模版js，主要是优化了调出菜单动画，以及二级菜单显示的一些问题。
- 解决“外观”“系统”对不齐的问题。并添加emlog_title的类名，以便后续优化。
- 主要是电脑端固定，手机端菜单左滑后固定页面，以及其余一些微调。
- 默认在大屏模式下显示预览
- 去掉了多余的代码，然后添加了“在大屏模式下，编辑器默认显示预览”