### PR TITLE
前台模版的优化，保存快捷键，编辑器添加js钩子

### DIFF
--- a/admin/views/article_write.php
+++ b/admin/views/article_write.php
@@ -196,6 +196,15 @@
                 if ($(window).width() > 767) {
                     this.watch();
                 }
+		//添加Ctrl(Cmd)+S快捷键保存文章内容
+                var articleSave = {
+                    "Ctrl-S": function(cm) {
+                    	autosave(2);
+                    },
+                    "Cmd-S": function(cm) {
+                    	autosave(2);
+                    }};
+                this.addKeyMap(articleSave);  
             }
         });
         Editor_summary = editormd("logexcerpt", {
@@ -219,5 +228,6 @@
         });
         Editor.setToolbarAutoFixed(false);
         Editor_summary.setToolbarAutoFixed(false);
+        editorHook(article);
     });
 </script>

--- a/admin/views/js/common.js
+++ b/admin/views/js/common.js
@@ -182,7 +182,7 @@ function autosave(act) {
         + "&ishide=" + ishide
         + "&as_logid=" + logid;
 
-    //检查别名
+    // 检查别名
     if (alias != '' && 0 != isalias(alias)) {
         $("#msg").show().html("链接别名错误，自动保存失败");
         if (act == 0) {
@@ -229,7 +229,7 @@ function autosave(act) {
     }
 }
 
-//toggle plugin
+// toggle plugin
 $.fn.toggleClick = function () {
     var functions = arguments;
     return this.click(function () {
@@ -240,7 +240,7 @@ $.fn.toggleClick = function () {
     });
 };
 
-//过滤HTML标签
+// 过滤HTML标签
 function removeHTMLTag(str) {
     str = str.replace(/<\/?[^>]*>/g, ''); //去除HTML tag
     str = str.replace(/[ | ]*\n/g, '\n'); //去除行尾空白
@@ -262,3 +262,5 @@ $(function () {
         event.stopPropagation();
     });
 });
+// 定义editor.md编辑器的事件钩子，可通过插件实现编辑器功能的扩展
+function editorHook(sort) {}

--- a/admin/views/page_create.php
+++ b/admin/views/page_create.php
@@ -132,8 +132,18 @@
                     if($(window).width() > 767){
                         this.watch();
                     }
+                    //添加Ctrl(Cmd)+S快捷键保存文章内容
+                    var articleSave = {
+                    "Ctrl-S": function(cm) {
+                    	autosave(2);
+                    },
+                    "Cmd-S": function(cm) {
+                    	autosave(2);
+                    }};
+                    this.addKeyMap(articleSave);  
             }
         });
         Editor_page.setToolbarAutoFixed(false);
+	editorHook(page);    
     });
 </script>

--- a/content/templates/default/css/main.css
+++ b/content/templates/default/css/main.css
@@ -936,10 +936,6 @@ body {
         margin-bottom: 0px
     }
 
-    .bloggerinfo_img {
-        display: none
-    }
-
     .mb-5, .my-5 {
         margin-bottom: 2rem !important
     }

--- a/content/templates/default/css/markdown.css
+++ b/content/templates/default/css/markdown.css
@@ -138,7 +138,6 @@
 .log_con pre {
     padding: 10px;
     border: 1px solid #ddd;
-    white-space: pre-wrap;
     background: #f6f6f6
 }
 


### PR DESCRIPTION
- 既然模版又做了调整，那就顺便进一步优化一下模版吧。
- 添加了保存快捷键 [ ctrl ( cmd ) + s ]
- 添加了钩子。可以通过在header.php部的钩子，引进JaveScript代码，对common.js中的editorHook()函数进行覆盖，实现编辑器的扩展操作。