### PR TITLE
get_news - Use header() only once

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -39,11 +39,10 @@ if (empty($action)) {
 if ($action === 'get_news') {
 	$emcurl = new EmCurl();
 	$emcurl->request(OFFICIAL_SERVICE_HOST . 'services/messenger_pro.php');
+	header('Content-Type: application/json; charset=UTF-8');
 	if ($emcurl->getHttpStatus() !== 200) {
-		header('Content-Type: application/json; charset=UTF-8');
 		exit('{"result":"fail"}');
 	}
 	$response = $emcurl->getRespone();
-	header('Content-Type: application/json; charset=UTF-8');
 	exit($response);
 }


### PR DESCRIPTION
There is a duplicated code line in admin/index.php in lines 42 & 46:
`header('Content-Type: application/json; charset=UTF-8');`
I offer to use it only once for the code minimization!
