### PR TITLE
一些前端优化

### DIFF
--- a/admin/views/article_write.php
+++ b/admin/views/article_write.php
@@ -326,4 +326,16 @@
             $('#cover_rm').hide();
         });
     });
+
+    // 离开页面时，如果文章内容已做修改，则询问用户是否离开
+    var articleText;
+    hooks.addAction("loaded", function(){
+        articleText = $("textarea[name=logcontent]").text();
+    });
+    window.onbeforeunload = function (e) {
+        if($("textarea[name=logcontent]").text() == articleText) return
+        e = e || window.event;
+        if (e) e.returnValue = '离开页面提示';
+        return '离开页面提示';
+    }
 </script>

--- a/admin/views/blogger.php
+++ b/admin/views/blogger.php
@@ -64,6 +64,7 @@
                 </div>
                 <div class="form-group">
                     <label>新密码（不小于6位，不修改请留空）</label>
+                    <input type="password" name="hidden-auto-filling" style="width: 0;border: 0;opacity: 0">
                     <input type="password" class="form-control" value="" name="newpass">
                 </div>
                 <div class="form-group">
@@ -80,7 +81,7 @@
     </div>
 </div>
 
-<div class="modal fade" id="modal" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
+<div class="modal fade" id="modal" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true" data-backdrop="static">
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">

--- a/admin/views/page_create.php
+++ b/admin/views/page_create.php
@@ -151,5 +151,17 @@
             }
         });
         Editor.setToolbarAutoFixed(false);
+
+        // 离开页面时，如果页面内容已做修改，则询问用户是否离开
+        var pageText;
+        hooks.addAction("page_loaded", function(){
+            pageText = $("textarea").text();
+        });
+        window.onbeforeunload = function (e) {
+            if($("textarea").text() == pageText) return
+            e = e || window.event;
+            if (e) e.returnValue = '离开页面提示';
+            return '离开页面提示';
+        }
     });
 </script>

--- a/content/templates/default/css/markdown.css
+++ b/content/templates/default/css/markdown.css
@@ -66,6 +66,10 @@
     text-decoration: line-through
 }
 
+.markdown a{
+    text-decoration: underline;
+}
+
 .markdown blockquote {
     color: #666;
     border-left: 4px solid #ddd;

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -214,8 +214,8 @@ footer .copyright {
     padding: 1rem 0.5rem 1rem 0.5rem
 }
 .list-menu {
-		list-style: none
-	}
+	list-style: none
+}
 
 /* 导航列表的响应式配置
    在不同大小的屏幕上，导航菜单会有不同的样式。
@@ -908,58 +908,6 @@ footer .copyright {
 }
 @media (max-width:415px) {.loglist-cover{ height: 160px;overflow: hidden}.loglist-cover img {position:unset;    width: 730px;}}
 @media (max-width:375px) {.loglist-cover{ height: 140px;overflow: hidden}.loglist-cover img {position:unset;    width: 730px;}}
-/* 回形针 */
-.clip,
-.clip::after,
-.clip::before {
-    border-color: white!important;
-}
-.clip {
-    margin-top: -38px;
-    width: 40px;
-    margin-bottom: 40px;
-    border-bottom: none;
-    border-left: 0px solid;
-    border-right: 6px solid;
-    border-top: none;
-    position: relative;
-    z-index: 5;
-    box-shadow: 10px 40px 100px 10px rgb(115 115 115)
-}
-/* 自适应位置，使其始终在封面图右侧向左95px */
-@media (max-width:575px) {.clip{display: none}}
-@media (min-width:576px) {.clip{left: calc(510px - 95px)}}
-@media (min-width:768px) {.clip{left: calc(450px - 95px)}}
-@media (min-width:992px) {.clip{left: calc(600px - 95px)}}
-@media (min-width:1201px) {.clip{left: calc(730px - 95px)}}
-.clip::before {
-    position: absolute;
-    content: "";
-    top: -5px;
-    right: -9px;
-    width: 14px;
-    height: 33px;
-    border-top-left-radius: 40px;
-    border-top-right-radius: 40px;
-    border-bottom: none;
-    border-left: 6px solid;
-    border-right: 6px solid;
-    border-top: 6px solid
-}
-.clip::after {
-    position: absolute;
-    content: "";
-    bottom: -80px;
-    right: 1px;
-    width: 4px;
-    height: 56px;
-    border-bottom-left-radius: 40px;
-    border-bottom-right-radius: 40px;
-    border-top: none;
-    border-left: 6px solid;
-    border-right: 6px solid;
-    border-bottom: 6px solid
-}
 /* 条目的其他内容 */
 .loglist-content {
     font-size: medium;
@@ -1029,6 +977,7 @@ footer .copyright {
 }
 /* 侧边栏组件中的标签 */
 .tag-container {
+    margin-block: 0;
     text-overflow: ellipsis;
     overflow: hidden
 }
@@ -1039,7 +988,7 @@ footer .copyright {
     white-space: nowrap
 }
 /* 侧边栏组件中的最新文章样式 */
-.blog-lates {
+.blog-lates,.blog-hot {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis

--- a/content/templates/default/echo_log.php
+++ b/content/templates/default/echo_log.php
@@ -11,7 +11,7 @@ if (!defined('EMLOG_ROOT')) {
     <span class="back-top mh" onclick="history.go(-1);">&laquo;</span>
     <header class="log-title"><?php topflg($top) ?><?= $log_title ?></header>
     <p class="date">
-        <b>时间：</b><?= gmdate('Y-n-j', $date) ?>&nbsp;&nbsp;&nbsp;
+        <b>时间：</b><?= date('Y-n-j', $date) ?>&nbsp;&nbsp;&nbsp;
         <b>作者：</b><?php blog_author($author) ?>&nbsp;&nbsp;&nbsp;
         <b>分类：</b><?php blog_sort($logid) ?>
 

--- a/content/templates/default/header.php
+++ b/content/templates/default/header.php
@@ -39,9 +39,9 @@ require_once View::getView('module');
         <div class="blog-header-subtitle"><?= $bloginfo ?></div>
         <div class="blog-header-toggle">
             <svg  class="blogtoggle-icon" >
-                <rect x="0.98" y="0.95" fill="#5F5F5F" width="26.05" height="1.66"/>
-                <rect x="1.02" y="8.18" fill="#5F5F5F" width="26.05" height="1.66"/>
-                <rect x="0.98" y="16.23" fill="#5F5F5F" width="26.05" height="1.66"/>
+                <rect x="1" y="1" fill="#5F5F5F" width="26" height="1.6"/>
+                <rect x="1" y="8" fill="#5F5F5F" width="26" height="1.6"/>
+                <rect x="1" y="15" fill="#5F5F5F" width="26" height="1.6"/>
             </svg>
         </div>
 

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -1,4 +1,4 @@
-  "use strict"
+"use strict"
 
 /**
  * jqurey添加动画扩展。先加速度至配速的50%，再减速到零
@@ -21,9 +21,15 @@ var myBlog = {
         $(".commentform #comment").css("height","140px")
                                   .css('border-radius', '10px')
       }
-      $(".markdown img").attr("data-action","zoom")  // 为摘要、文章、页面中图片添加“查看大图”
-                        .parent().removeAttr("href")
-                        .parent("p").css("text-align","center")
+      for(let num = 0;num < $(".markdown img").length;num++){  // 为正文中的图片添加查看大图，居中功能（默认认为图片父标签<a>中的链接为图片原地址）
+        let $this     = $(".markdown img:eq("+ num +")")
+        let sourceSrc = $(".markdown img:eq("+ num +")").parent().attr('href')
+
+        $this.attr("data-action","zoom")
+             .parent().attr("sourcesrc",sourceSrc)
+             .removeAttr("href")
+             .parent("p").css("text-align","center")
+      }
       $("#commentform").attr("onsubmit","return myBlog.comSubmitTip()")  // 评论提交在表单验证未通过的情况下是不能提交的
     },
     /**
@@ -68,7 +74,7 @@ var myBlog = {
      */
     calMargin : function($t) {
       if (window.outerWidth < 992) return
-      var $fatherLink,$childMenu,menuWidth,count
+      var $childMenu,menuWidth,count
 
       menuWidth     = 135  // 大屏幕端的子导航下拉框宽度(px)，可根据需要修改
       count         = ($t.outerWidth() - menuWidth)/2 + "px"
@@ -89,7 +95,6 @@ var myBlog = {
 
         let isCn       = $('#commentform').attr('is-chinese')
         let comContent = $('#comment').val()
-        let name       = $('#info_n').val()
         let mail       = $('#info_m').val()
         let url        = $('#info_u').val()
 
@@ -131,6 +136,14 @@ var myBlog = {
       $t.attr("src", "./include/lib/checkcode.php?" + timestamp)
     },
     /**
+     * 图片在点击时，将略缩图转化为原图
+     */
+    toggleImgSrc : function($t) {
+      $t.addClass('zoomFocus')
+      $t.attr('src2',$t.attr('src'))
+      $t.attr('src',$t.parent().attr('sourcesrc'))
+    },
+    /**
      * toc 分析
      * 
      * 启用toc目录方式: 在文章最开头写上'[toc]'或者'<!--[toc]-->',最好是单独一行
@@ -169,7 +182,6 @@ var myBlog = {
       }
       this.tocRender()
     },
-
     /**
      * toc 目录渲染
      */ 
@@ -291,5 +303,9 @@ $(document).ready(function(){
 
   $(".form-control").blur(function () {
     myBlog.comSubmitTip('judge')
+  }),
+
+  $(".markdown img").click(function () {
+    myBlog.toggleImgSrc($(this))
   })
 })

--- a/content/templates/default/js/zoom.js
+++ b/content/templates/default/js/zoom.js
@@ -4,32 +4,32 @@
  */
  +function ($) { "use strict";
  function ZoomService () {
- this._activeZoom=
- this._initialScrollPosition =
- this._initialTouchPosition=
- this._touchMoveListener = null
- this._$document = $(document)
- this._$window = $(window)
- this._$body = $(document.body)
- this._boundClick = $.proxy(this._clickHandler, this)
+   this._activeZoom=
+   this._initialScrollPosition =
+   this._initialTouchPosition=
+   this._touchMoveListener = null
+   this._$document = $(document)
+   this._$window = $(window)
+   this._$body = $(document.body)
+   this._boundClick = $.proxy(this._clickHandler, this)
  }
  ZoomService.prototype.listen = function () {
- this._$body.on('click', '[data-action="zoom"]', $.proxy(this._zoom, this))
+   this._$body.on('click', '[data-action="zoom"]', $.proxy(this._zoom, this))  
  }
  ZoomService.prototype._zoom = function (e) {
- var target = e.target
- if (!target || target.tagName != 'IMG') return
- if (this._$body.hasClass('zoom-overlay-open')) return
- if (e.metaKey || e.ctrlKey) {
- return window.open((e.target.getAttribute('data-original') || e.target.src), '_blank')
+   var target = e.target
+   if (!target || target.tagName != 'IMG') return
+   if (this._$body.hasClass('zoom-overlay-open')) return
+   if (e.metaKey || e.ctrlKey) {
+   return window.open((e.target.getAttribute('data-original') || e.target.src), '_blank')
  }
  if (target.width >= ($(window).width() - Zoom.OFFSET)) return
- this._activeZoomClose(true)
- this._activeZoom = new Zoom(target)
- this._activeZoom.zoomImage()
- this._$window.on('scroll.zoom', $.proxy(this._scrollHandler, this))
- this._$document.on('keyup.zoom', $.proxy(this._keyHandler, this))
- this._$document.on('touchstart.zoom', $.proxy(this._touchStart, this))
+   this._activeZoomClose(true)
+   this._activeZoom = new Zoom(target)
+   this._activeZoom.zoomImage()
+   this._$window.on('scroll.zoom', $.proxy(this._scrollHandler, this))
+   this._$document.on('keyup.zoom', $.proxy(this._keyHandler, this))
+   this._$document.on('touchstart.zoom', $.proxy(this._touchStart, this))
  if (document.addEventListener) {
  document.addEventListener('click', this._boundClick, true)
  } else {
@@ -44,22 +44,31 @@
  ZoomService.prototype._activeZoomClose = function (forceDispose) {
  if (!this._activeZoom) return
  if (forceDispose) {
- this._activeZoom.dispose()
+   this._activeZoom.dispose() 
  } else {
- this._activeZoom.close()
+   this._activeZoom.close()
  }
- this._$window.off('.zoom')
- this._$document.off('.zoom')
- document.removeEventListener('click', this._boundClick, true)
- this._activeZoom = null
+   this._$window.off('.zoom')
+   this._$document.off('.zoom')
+   document.removeEventListener('click', this._boundClick, true)
+   this._activeZoom = null
+
+   /* 修改：在关闭图片后，图片恢复原来的地址 */
+   let $zoomImg = $('.zoomFocus')
+   $zoomImg.attr('src',$zoomImg.attr('src2'))
+           .removeClass('zoomFocus')
+
  }
- ZoomService.prototype._scrollHandler = function (e) {
- if (this._initialScrollPosition === null) this._initialScrollPosition = $(window).scrollTop()
- var deltaY = this._initialScrollPosition - $(window).scrollTop()
- if (Math.abs(deltaY) >= 40) this._activeZoomClose()
- }
+
+/* 修改：注释掉了滚轮滚动可关闭图片的设定 */
+//  ZoomService.prototype._scrollHandler = function (e) {
+//  if (this._initialScrollPosition === null) this._initialScrollPosition = $(window).scrollTop()
+//  var deltaY = this._initialScrollPosition - $(window).scrollTop()
+//  if (Math.abs(deltaY) >= 40) this._activeZoomClose()
+//  }
+
  ZoomService.prototype._keyHandler = function (e) {
- if (e.keyCode == 27) this._activeZoomClose()
+   if (e.keyCode == 27) this._activeZoomClose()
  }
  ZoomService.prototype._clickHandler = function (e) {
  if (e.preventDefault) e.preventDefault()
@@ -67,53 +76,53 @@
  if ('bubbles' in e) {
  if (e.bubbles) e.stopPropagation()
  } else {
- e.cancelBubble = true
+   e.cancelBubble = true
  }
- this._activeZoomClose()
+   this._activeZoomClose()
  }
  ZoomService.prototype._touchStart = function (e) {
- this._initialTouchPosition = e.touches[0].pageY
- $(e.target).on('touchmove.zoom', $.proxy(this._touchMove, this))
+   this._initialTouchPosition = e.touches[0].pageY
+   $(e.target).on('touchmove.zoom', $.proxy(this._touchMove, this))
  }
  ZoomService.prototype._touchMove = function (e) {
  if (Math.abs(e.touches[0].pageY - this._initialTouchPosition) > 10) {
- this._activeZoomClose()
- $(e.target).off('touchmove.zoom')
+   this._activeZoomClose()
+   $(e.target).off('touchmove.zoom')
  }
  }
  function Zoom (img) {
- this._fullHeight=
- this._fullWidth =
- this._overlay =
- this._targetImageWrap = null
- this._targetImage = img
- this._$body = $(document.body)
+   this._fullHeight=
+   this._fullWidth =
+   this._overlay =
+   this._targetImageWrap = null
+   this._targetImage = img
+   this._$body = $(document.body)
  }
  Zoom.OFFSET = 80
  Zoom._MAX_WIDTH = 2560
  Zoom._MAX_HEIGHT = 4096
  Zoom.prototype.zoomImage = function () {
- var img = document.createElement('img')
- img.onload = $.proxy(function () {
- this._fullHeight = Number(img.height)
- this._fullWidth = Number(img.width)
- this._zoomOriginal()
- }, this)
- img.src = this._targetImage.src
+   var img = document.createElement('img')
+   img.onload = $.proxy(function () {
+      this._fullHeight = Number(img.height)
+      this._fullWidth = Number(img.width)
+      this._zoomOriginal()
+   }, this)
+   img.src = this._targetImage.src
  }
  Zoom.prototype._zoomOriginal = function () {
- this._targetImageWrap = document.createElement('div')
- this._targetImageWrap.className = 'zoom-img-wrap'
- this._targetImage.parentNode.insertBefore(this._targetImageWrap, this._targetImage)
- this._targetImageWrap.appendChild(this._targetImage)
- $(this._targetImage)
- .addClass('zoom-img cover-unclip')
- .attr('data-action', 'zoom-out')
- this._overlay = document.createElement('div')
- this._overlay.className = 'zoom-overlay'
- document.body.appendChild(this._overlay)
- this._calculateZoom()
- this._triggerAnimation()
+   this._targetImageWrap = document.createElement('div')
+   this._targetImageWrap.className = 'zoom-img-wrap'
+   this._targetImage.parentNode.insertBefore(this._targetImageWrap, this._targetImage)
+   this._targetImageWrap.appendChild(this._targetImage)
+   $(this._targetImage)
+   .addClass('zoom-img cover-unclip')
+   .attr('data-action', 'zoom-out')
+   this._overlay = document.createElement('div')
+   this._overlay.className = 'zoom-overlay'
+   document.body.appendChild(this._overlay)
+   this._calculateZoom()
+   this._triggerAnimation()
  }
  Zoom.prototype._calculateZoom = function (img) {
  this._targetImage.offsetWidth
@@ -185,20 +194,20 @@
  'transform': ''
  })
  if (!$.support.transition) {
- return this.dispose()
+   return this.dispose()
  }
- $(this._targetImage)
- .one($.support.transition.end, $.proxy(this.dispose, this))
- .emulateTransitionEnd(300)
+   $(this._targetImage)
+   .one($.support.transition.end, $.proxy(this.dispose, this))
+   .emulateTransitionEnd(300)
  }
  Zoom.prototype.dispose = function () {
  if (this._targetImageWrap && this._targetImageWrap.parentNode) {
- $(this._targetImage)
- .removeClass('zoom-img cover-unclip')
- .attr('data-action', 'zoom')
- this._targetImageWrap.parentNode.replaceChild(this._targetImage, this._targetImageWrap)
- this._overlay.parentNode.removeChild(this._overlay)
- this._$body.removeClass('zoom-overlay-transitioning')
+   $(this._targetImage)
+   .removeClass('zoom-img cover-unclip')
+   .attr('data-action', 'zoom')
+   this._targetImageWrap.parentNode.replaceChild(this._targetImage, this._targetImageWrap)
+   this._overlay.parentNode.removeChild(this._overlay)
+   this._$body.removeClass('zoom-overlay-transitioning')
  }
  }
  $(function () {

--- a/content/templates/default/log_list.php
+++ b/content/templates/default/log_list.php
@@ -16,10 +16,8 @@ if (!defined('EMLOG_ROOT')) {
                     <div class="shadow-theme bottom-5">
 						<?php if (!empty($value['log_cover'])) : ?>
                             <div class="loglist-cover">
-                                <a href="<?= $value['log_url'] ?>"></a>
                                 <img src="<?= $value['log_cover'] ?>" class="rea-width" data-action="zoom">
                             </div>
-                            <div class="clip"></div>
 						<?php endif ?>
                         <div class="card-padding loglist-body">
                             <h3 class="card-title">
@@ -32,7 +30,7 @@ if (!defined('EMLOG_ROOT')) {
                         <hr class="list-line"/>
                         <div class="row info-row">
                             <div class="log-info">
-								<?php blog_author($value['author']) ?>&nbsp;发布于&nbsp;<?= gmdate('Y-n-j', $value['date']) ?>&nbsp;<span class="mh"><?= gmdate('H:i', $value['date']) ?></span>
+								<?php blog_author($value['author']) ?>&nbsp;发布于&nbsp;<?= date('Y-n-j', $value['date']) ?>&nbsp;<span class="mh"><?= date('H:i', $value['date']) ?></span>
                             </div>
                             <div class="log-count">
                                 <a href="<?= $value['log_url'] ?>#comments">评论(<?= $value['comnum'] ?>)&nbsp;</a>

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -166,7 +166,7 @@ function widget_newlog($title) {
         </div>
         <ul class="unstyle-li">
 			<?php foreach ($newLogs_cache as $value): ?>
-                <li class='blog-lates'><a href="<?= Url::log($value['gid']) ?>"><?= $value['title'] ?></a></li>
+                <li class="blog-lates"><a href="<?= Url::log($value['gid']) ?>"><?= $value['title'] ?></a></li>
 			<?php endforeach ?>
         </ul>
     </div>
@@ -185,7 +185,7 @@ function widget_hotlog($title) {
         </div>
         <ul class="unstyle-li">
 			<?php foreach ($hotLogs as $value): ?>
-                <li><a href="<?= Url::log($value['gid']) ?>"><?= $value['title'] ?></a></li>
+                <li class="blog-hot"><a href="<?= Url::log($value['gid']) ?>"><?= $value['title'] ?></a></li>
 			<?php endforeach ?>
         </ul>
     </div>
@@ -361,7 +361,6 @@ function blog_tag($blogid) {
 		}
 	}
 }
-
 ?>
 <?php
 /**
@@ -376,7 +375,6 @@ function blog_author($uid) {
 	$title = !empty($mail) || !empty($des) ? "title=\"$des $mail\"" : '';
 	echo '<a href="' . Url::author($uid) . "\" $title>$author</a>";
 }
-
 ?>
 <?php
 /**


### PR DESCRIPTION
前台：
1. markdown 中的a标签 ，在markdown.css中加上了下划线
2. img 的点击问题，这次可以在点击后放大的是原图
3. 主题显示（热门文章）的bug---隐藏换行
4. 前台时间显示bug修复
5. 标签显示bug，修复在Windows系统下，上下边距会隐藏的bug

后台：

1. 剪裁优化应用到了个人资料头像剪裁
2. 如果编辑内容做了修改，则在关闭编辑页面时会有提示
3. 解决了讨厌的谷歌浏览器在修改个人资料页面的密码自动填充