### PR TITLE
修复伪静态下，评论验证码可能无法刷新的bug

### DIFF
--- a/content/templates/default/header.php
+++ b/content/templates/default/header.php
@@ -20,6 +20,7 @@ require_once View::getView('module');
     <meta name="keywords" content="<?= $site_key ?>"/>
     <meta name="description" content="<?= $site_description ?>"/>
     <meta name="generator" content="emlog"/>
+    <base href="<?= BLOG_URL ?>" />
     <link rel="shortcut icon" href="<?= BLOG_URL ?>favicon.ico"/>
     <link rel="bookmark" href="<?= BLOG_URL ?>favicon.ico" type="image/x-icon" 　/>
     <link rel="alternate" title="RSS" href="<?= BLOG_URL ?>rss.php" type="application/rss+xml"/>

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -28,6 +28,7 @@ var myBlog = {
         $this.attr("data-action","zoom")
              .parent().attr("sourcesrc",sourceSrc)
              .removeAttr("href")
+             .parent("p").css("text-align","center")
       }
       $("#commentform").attr("onsubmit","return myBlog.comSubmitTip()")  // 评论提交在表单验证未通过的情况下是不能提交的
     },
@@ -132,7 +133,9 @@ var myBlog = {
      */
     captchaRefresh : function($t) {
       var timestamp   = new Date().getTime()
-      $t.attr("src", "./include/lib/checkcode.php?" + timestamp)
+      var blogUrl = $("base").attr("href")
+
+      $t.attr("src", blogUrl + "/include/lib/checkcode.php?" + timestamp)
     },
     /**
      * 图片在点击时，将略缩图转化为原图
@@ -271,7 +274,7 @@ var myBlog = {
 }
 
 /**
- * 监听
+ * 事件监听
  */
 $(document).ready(function(){
   myBlog.init()
@@ -297,7 +300,11 @@ $(document).ready(function(){
   }),
 
   $('#comment_submit[type="button"], #close-modal').click(function () {
-    myBlog.viewModal()
+    myBlog.comSubmitTip('judge')
+    if (myBlog.comSubmitTip()) {  // 在显示模态框前，先校验一下评论区内容
+      myBlog.viewModal()
+    }
+    
   }),
 
   $(".form-control").blur(function () {

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -28,7 +28,6 @@ var myBlog = {
         $this.attr("data-action","zoom")
              .parent().attr("sourcesrc",sourceSrc)
              .removeAttr("href")
-             .parent("p").css("text-align","center")
       }
       $("#commentform").attr("onsubmit","return myBlog.comSubmitTip()")  // 评论提交在表单验证未通过的情况下是不能提交的
     },


### PR DESCRIPTION
比如 emlog.com/fenlei/1.html   ,这个时候 js 刷新时，会以 emlog.com/fenlei/  而不是 emlog.com/为根目录寻找验证码php ，进而无法显示新验证，现在修复了这个问题。。

另外优化了 显示验证码的逻辑。