### PR TITLE
评论回复加自动换行、搜索框优化、去除后台评论回复时转义评论内容操作

### DIFF
--- a/admin/views/article.php
+++ b/admin/views/article.php
@@ -82,7 +82,7 @@ $isDisplayUser = !$uid ? "style=\"display:none;\"" : '';
             </div>
             <form action="article.php" method="get">
                 <div class="form-inline">
-                    <input type="text" name="keyword" class="form-control bg-light m-1 small" placeholder="查找文章..." aria-label="Search" aria-describedby="basic-addon2">
+                    <input type="text" name="keyword" class="form-control m-1 small" placeholder="查找文章..." aria-label="Search" aria-describedby="basic-addon2">
                     <div class="input-group-append">
                         <button class="btn btn-sm btn-success" type="submit">
                             <i class="icofont-search-2"></i>

--- a/admin/views/comment.php
+++ b/admin/views/comment.php
@@ -130,7 +130,7 @@
             </div>
             <form action="comment.php?action=doreply" method="post">
                 <div class="modal-body">
-                    <p></p>
+                    <p class="comment-replay-content"></p>
                     <div class="form-group">
                         <input type="hidden" value="" name="cid" id="cid"/>
                         <input type="hidden" value="" name="gid" id="gid"/>
@@ -170,7 +170,7 @@
         var gid = button.data('gid')
         var hide = button.data('hide')
         var modal = $(this)
-        modal.find('.modal-body p').html(removeHTMLTag(comment))
+        modal.find('.modal-body p').html(comment)
         modal.find('.modal-body #cid').val(cid)
         modal.find('.modal-body #gid').val(gid)
         modal.find('.modal-body #hide').val(hide)

--- a/admin/views/css/css-main.css
+++ b/admin/views/css/css-main.css
@@ -699,3 +699,7 @@ textarea {
     right: 105px;
 }
 
+/* 评论界面回复模态窗中的评论内容，需要自动换行 */
+.comment-replay-content {
+    overflow-wrap: break-word
+}

--- a/admin/views/js/common.js
+++ b/admin/views/js/common.js
@@ -440,3 +440,19 @@ function imgPasteExpand(thisEditor){
 // 把粘贴上传图片函数，挂载到位于文章编辑器、页面编辑器处的 js 钩子处
 hooks.addAction("loaded", imgPasteExpand);
 hooks.addAction("page_loaded", imgPasteExpand);
+
+// 设置界面，如果设置“自动检测地址”，则设置 input 为只读，以表示该项是无效的
+$(document).ready(function(){
+    // 网页加载完先检查一遍
+    if ($("#detect_url").prop("checked")){
+        $("[name=blogurl]").attr("readonly","readonly")
+    }
+
+    $("#detect_url").click(function(){
+      if ($(this).prop("checked")){
+        $("[name=blogurl]").attr("readonly","readonly")
+      }else{
+        $("[name=blogurl]").removeAttr("readonly")
+      }
+    })
+})


### PR DESCRIPTION
[fix:后台的评论回复模态框加上了自动换行](https://github.com/emlog/emlog/commit/421430f3f71e935c26ab59a76167d11be87d406d)[](https://github.com/kohunglee)
  
比如评论为 ‘sssss......’ （几百个 s）时，可以自动换行

[fix:使搜索框与用户搜索界面保持一致](https://github.com/emlog/emlog/commit/4c0d89288256f1e491c2a1e18b8d215ce7d0c1fe)[](https://github.com/kohunglee)
（口误，在 commit 的注释中写错了，应该是 *用户搜索界面*）
  
[fix:去除了清理标签，因为已经经过转义，没必要了](https://github.com/emlog/emlog/commit/22e4ebab894f1b3ab93fe1c14a67215c93fba888)

即使是默认的 stay hungry ，stay foolish 这句评论，在回复时的模态框，也会变成 stayhungrystayfoolish 