### PR TITLE
fix:直接以字符形式显示评论

### DIFF
--- a/admin/views/comment.php
+++ b/admin/views/comment.php
@@ -170,7 +170,7 @@
         var gid = button.data('gid')
         var hide = button.data('hide')
         var modal = $(this)
-        modal.find('.modal-body p').html(comment)
+        modal.find('.modal-body p').text(comment)
         modal.find('.modal-body #cid').val(cid)
         modal.find('.modal-body #gid').val(gid)
         modal.find('.modal-body #hide').val(hide)


### PR DESCRIPTION
html() 会有 XSS 风险，removeHTMLTag(str)又会删除空格，这里应该使用 text() ，才能完整且安全还原评论内容。