### PR TITLE
评论页面优化

### DIFF
--- a/admin/views/comment.php
+++ b/admin/views/comment.php
@@ -170,7 +170,7 @@
         var gid = button.data('gid')
         var hide = button.data('hide')
         var modal = $(this)
-        modal.find('.modal-body p').html(comment)
+        modal.find('.modal-body p').text(comment)
         modal.find('.modal-body #cid').val(cid)
         modal.find('.modal-body #gid').val(gid)
         modal.find('.modal-body #hide').val(hide)

--- a/admin/views/comment.php
+++ b/admin/views/comment.php
@@ -68,7 +68,8 @@
 						$cid = $value['cid'];
 						$ip_info = $ip ? "<br />来自IP：{$ip}" : '';
 						$comment = $value['comment'];
-						$poster = $value['poster'] ?: '';
+                        $url = $value['url'];
+						$poster = !empty($value['url']) ? '<a href="'.$value['url'].'" target="_blank">'. $value['poster'].'</a>' : $value['poster'];
 						$title = subString($value['title'], 0, 42);
 						$hide = $value['hide'];
 						$date = $value['date'];
@@ -165,12 +166,12 @@
 
     $('#replyModal').on('show.bs.modal', function (event) {
         var button = $(event.relatedTarget)
-        var comment = button.data('comment')
+        var comment = button.html()
         var cid = button.data('cid')
         var gid = button.data('gid')
         var hide = button.data('hide')
         var modal = $(this)
-        modal.find('.modal-body p').text(comment)
+        modal.find('.modal-body p').html(comment)
         modal.find('.modal-body #cid').val(cid)
         modal.find('.modal-body #gid').val(gid)
         modal.find('.modal-body #hide').val(hide)

--- a/admin/views/comment.php
+++ b/admin/views/comment.php
@@ -68,7 +68,6 @@
 						$cid = $value['cid'];
 						$ip_info = $ip ? "<br />来自IP：{$ip}" : '';
 						$comment = $value['comment'];
-                        $url = $value['url'];
 						$poster = !empty($value['url']) ? '<a href="'.$value['url'].'" target="_blank">'. $value['poster'].'</a>' : $value['poster'];
 						$title = subString($value['title'], 0, 42);
 						$hide = $value['hide'];


### PR DESCRIPTION
1. 因为前台显示的评论内容的 html 是原内容经过 php 转义后的，故没有 xss 风险，所以可以直接使用 jq 取评论显示区的 html 放到模态框里显示，这样就会原汁原味呈现评论内容。

2. 个人感觉后台还是有必要把评论人的链接显示出来的，这里复制了一下 531 的写法。