### PR TITLE
fix:移动端页面高度以及搜索框前端显示问题

### DIFF
--- a/admin/views/article.php
+++ b/admin/views/article.php
@@ -81,7 +81,7 @@ $isDisplayUser = !$uid ? "style=\"display:none;\"" : '';
 				<?php endif ?>
             </div>
             <form action="article.php" method="get">
-                <div class="form-inline">
+                <div class="form-inline search-inputs-nowrap">
                     <input type="text" name="keyword" class="form-control m-1 small" placeholder="查找文章..." aria-label="Search" aria-describedby="basic-addon2">
                     <div class="input-group-append">
                         <button class="btn btn-sm btn-success" type="submit">

--- a/admin/views/css/css-main.css
+++ b/admin/views/css/css-main.css
@@ -614,7 +614,9 @@ textarea {
     }
 
     #content-wrapper {
-        min-height: 752px;
+        /* 使移动端页面的高度始终大于菜单栏高度，小于屏幕高度，以防止露出菜单栏  */
+        min-height: 800px;
+        height: 100vh;
         position: absolute;
     }
 
@@ -640,7 +642,7 @@ textarea {
     }
 
     /* 用户查询搜索框和按钮两个元素在移动端不换行 */
-    .form-inline {
+    .search-inputs-nowrap {
         flex-flow: nowrap
     }
 }

--- a/admin/views/user.php
+++ b/admin/views/user.php
@@ -30,7 +30,7 @@
                 <h6 class="m-0 font-weight-bold">总用户数 (<?= $usernum ?>)</h6>
             </div>
             <form action="user.php" method="get">
-                <div class="form-inline">
+                <div class="form-inline search-inputs-nowrap">
                     <input type="text" name="email" value="<?= $email ?>" class="form-control m-1 small" placeholder="按邮箱搜索用户...">
                     <div class="input-group-append">
                         <button class="btn btn-sm btn-success" type="submit">


### PR DESCRIPTION
1. 优化之前解决搜索框换行问题的方法。

因为 “form-inline” 这个 class 很多地方都在用，其中一些地方不适合直接 width:100% 和整体化（且不自动换行），所以新建一个 class “search-inputs-nowrap” ，只作用于这两个搜索框，完美解决它们在移动端身首分离的问题。

2. 上午解决页面高度的方法并不完美，现在决定加个初始高度 100vh ，以避免它们在超长手机上显示时出现高度不足的问题