### PR TITLE
修正代码使其完全符合 W3C 验证器、后台顶栏美化和编辑器添加帮助图标

### DIFF
--- a/admin/editor.md/plugins/help-dialog/help-dialog.js
+++ b/admin/editor.md/plugins/help-dialog/help-dialog.js
@@ -28,7 +28,97 @@
 
 			if (editor.find("." + dialogName).length < 1)
 			{			
-				var dialogContent = "<div class=\"markdown-body\" style=\"font-family:微软雅黑, Helvetica, Tahoma, STXihei,Arial;height:390px;overflow:auto;font-size:14px;border-bottom:1px solid #ddd;padding:0 20px 20px 0;\"></div>";
+				var dialogContent = `<div class=\"markdown-body\" style=\"font-family:微软雅黑, Helvetica, Tahoma, STXihei,Arial;height:390px;overflow:auto;font-size:14px;border-bottom:1px solid #ddd;padding:0 20px 20px 0;\">
+				<h5>Markdown语法教程</h5><ul>
+				<li><p><a href="http://daringfireball.net/projects/markdown/syntax/" title="Markdown Syntax">Markdown Syntax</a></p>
+				</li><li><p><a href="https://guides.github.com/features/mastering-markdown/" title="Mastering Markdown">Mastering Markdown</a></p>
+				</li><li><p><a href="https://help.github.com/articles/markdown-basics/" title="Markdown Basics">Markdown Basics</a></p>
+				</li><li><p><a href="https://help.github.com/articles/github-flavored-markdown/" title="GitHub Flavored Markdown">GitHub Flavored Markdown</a></p>
+				</li><li><p><a href="http://www.markdown.cn/" title="Markdown 语法说明（简体中文）">Markdown 语法说明（简体中文）</a></p>
+				</li><li><p><a href="http://markdown.tw/" title="Markdown 語法說明（繁體中文）">Markdown 語法說明（繁體中文）</a></p>
+				</li></ul>
+				<h5 id="h5--keyboard-shortcuts-">键盘快捷键</h5><blockquote>
+				<p>快捷键表格中的Ctrl与Alt，在Mac系统中可分别被Cmd与Opt取代。</p>
+				</blockquote>
+				<table>
+					<thead>
+					<tr>
+					<th style="text-align: center;"><strong><strong>CTRL + S</strong></strong></th>
+					<th style="text-align: center;">保存</th>
+					<th style="text-align: center;"><strong><strong>F9</strong></strong></th>
+					<th style="text-align: center;">切换实时预览</th>
+					<th style="text-align: center;"><strong><strong>CTRL + SHIFT + R</strong></strong></th>
+					<th style="text-align: center;">全部替换</th>
+					</tr>
+					</thead>
+					<tbody>
+					<tr>
+					<td style="text-align: center;"><strong><strong>Ctrl+1~6</strong></strong></td>
+					<td style="text-align: center;">分别对应H1到H6</td>
+					<td style="text-align: center;"><strong><strong>F10</strong></strong></td>
+					<td style="text-align: center;">编辑器全屏预览</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + D</strong></strong></td>
+					<td style="text-align: center;">当前时间</td>
+					</tr>
+					<tr>
+					<td style="text-align: center;"><strong><strong>Ctrl + U</strong></strong></td>
+					<td style="text-align: center;">无序列表</td>
+					<td style="text-align: center;"><strong><strong>按住Ctrl键的同时，选择编辑区的不同地方</strong></strong></td>
+					<td style="text-align: center;">多光标选择</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + H</strong></strong></td>
+					<td style="text-align: center;">水平线</td>
+					</tr>
+					<tr>
+					<td style="text-align: center;"><strong><strong>Ctrl + B</strong></strong></td>
+					<td style="text-align: center;">粗体</td>
+					<td style="text-align: center;"><strong><strong>Ctrl+ A</strong></strong></td>
+					<td style="text-align: center;">全选</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + L</strong></strong></td>
+					<td style="text-align: center;">链接</td>
+					</tr>
+					<tr>
+					<td style="text-align: center;"><strong><strong>Ctrl + I</strong></strong></td>
+					<td style="text-align: center;">斜体</td>
+					<td style="text-align: center;"><strong><strong>Ctrl+ Z</strong></strong></td>
+					<td style="text-align: center;">撤销</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + Shift + A</strong></strong></td>
+					<td style="text-align: center;">Github链接</td>
+					</tr>
+					<tr>
+					<td style="text-align: center;"><strong><strong>Ctrl + K</strong></strong></td>
+					<td style="text-align: center;">行内代码</td>
+					<td style="text-align: center;"><strong><strong>Ctrl+ Y</strong></strong></td>
+					<td style="text-align: center;">重做</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + Shift + I</strong></strong></td>
+					<td style="text-align: center;">图片</td>
+					</tr>
+					<tr>
+					<td style="text-align: center;"><strong><strong>Shift + Alt + L</strong></strong></td>
+					<td style="text-align: center;">所选文本转为小写</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + F</strong></strong></td>
+					<td style="text-align: center;">查找搜索</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + Shift + C</strong></strong></td>
+					<td style="text-align: center;">代码区块</td>
+					</tr>
+					<tr>
+					<td style="text-align: center;"><strong><strong>Shift + Alt+ U</strong></strong></td>
+					<td style="text-align: center;">首字母转为大写</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + Shift + G</strong></strong></td>
+					<td style="text-align: center;">上一个结果</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + Shift + P</strong></strong></td>
+					<td style="text-align: center;">Pre标签代码区块</td>
+					</tr>
+					<tr>
+					<td style="text-align: center;"><strong><strong>Ctrl + Alt + G</strong></strong></td>
+					<td style="text-align: center;">跳转到行</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + G</strong></strong></td>
+					<td style="text-align: center;">下一个结果</td>
+					<td style="text-align: center;"><strong><strong>Ctrl + Shift + H</strong></strong></td>
+					<td style="text-align: center;">Html实体字符</td>
+					</tr>
+					</tbody>
+					</table>
+				</div>`;
 
 				dialog = this.createDialog({
 					name       : dialogName,
@@ -59,6 +149,7 @@
 			this.dialogLockScreen();
 			dialog.show();
 
+			/* 
 			var helpContent = dialog.find(".markdown-body");
 
 			if (helpContent.html() === "") 
@@ -70,6 +161,7 @@
                     helpContent.find("a").attr("target", "_blank");
 				});
 			}
+			*/
 		};
 
 	};

--- a/admin/views/article_write.php
+++ b/admin/views/article_write.php
@@ -225,7 +225,7 @@
             height: 640,
             toolbarIcons: function () {
                 return ["undo", "redo", "|", "bold", "del", "italic", "quote", "|", "h1", "h2", "h3", "|", "list-ul", "list-ol", "hr", "|",
-                    "link", "image", "preformatted-text", "code-block", "table", "|", "search", "watch"]
+                    "link", "image", "preformatted-text", "code-block", "table", "|", "search", "watch", "help"]
             },
             path: "editor.md/lib/",
             tex: false,

--- a/admin/views/css/css-main.css
+++ b/admin/views/css/css-main.css
@@ -576,6 +576,10 @@ textarea {
         width: 100%;
         position: fixed;
         z-index: 1;
+        height: 50px;
+        /* 顶部导航条磨砂效果 */
+        background-color: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(4px);
     }
 
     .ml-md-3, .mx-md-3 {

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -123,7 +123,7 @@
     </ul>
     <div id="content-wrapper" class="d-flex flex-column">
         <div id="content">
-            <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
+            <nav class="navbar navbar-expand navbar-light topbar mb-4 static-top shadow">
                 <button id="sidebarToggleTop" class="btn d-md-none rounded-circle mr-3">
                     <i class="icofont-navigation-menu"></i>
                 </button>

--- a/admin/views/page_create.php
+++ b/admin/views/page_create.php
@@ -124,7 +124,7 @@
                     "bold", "del", "italic", "quote", "|",
                     "h1", "h2", "h3", "|",
                     "list-ul", "list-ol", "hr", "|",
-                    "link", "image", "preformatted-text", "table", "|", "watch"]
+                    "link", "image", "preformatted-text", "table", "|", "watch","help"]
             },
             path: "editor.md/lib/",
             tex: false,

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -812,7 +812,7 @@ footer .copyright {
 .log-con .date {
     margin-bottom: 0px
 }
-.log-con article {
+.log-con .markdown {
     margin-inline: 5px;
 }
 .loglist-content h1 {
@@ -885,13 +885,13 @@ footer .copyright {
     opacity: 0.8;
     border-radius: var(--marRadius) 10px 0 0;
     transition: all 0.4s;
-    clip: rect(50px 730px 250px 0px);
+    clip: rect(50px,730px,250px,0px);
     margin-top: -50px
 }
 .loglist-cover img:hover {
     opacity: 0.7;
     transform: scale(1.01);
-    clip: rect(50px 730px 250px 0px)
+    clip: rect(50px,730px,250px,0px)
 }
 /* 文章分类 */
 .loglist-sort {
@@ -947,7 +947,7 @@ footer .copyright {
     margin-top: 15px;
     margin-bottom: 0px
 }
-.bloginfo-cache {
+.bloginfo-descript {
     margin-top: 20px;
     margin-bottom: 15px;
     color: #929292
@@ -979,7 +979,6 @@ footer .copyright {
     text-overflow: ellipsis
 }
 .tags-side {
-    border: 1px solid #e8e8e8;
     padding: 2px 6px;
     border-radius: 4px;
     white-space: nowrap
@@ -1127,14 +1126,12 @@ img.zoom-img {
     right: 0;
     bottom: 0;
     pointer-events: none;
-    filter: "alpha(opacity=0)";
     opacity: 0;
     -webkit-transition:      opacity 300ms;
          -o-transition:      opacity 300ms;
             transition:      opacity 300ms;
   }
 .zoom-overlay-open .zoom-overlay {
-    filter: "alpha(opacity=100)";
     opacity: 1;
   }
 .zoom-overlay-open,
@@ -1240,7 +1237,7 @@ img.zoom-img {
 
     /* 展开菜单后，博客头部的下边距变大 */
     .bottom-change {
-        margin-bottom: 13pxs
+        margin-bottom: 13px
     }
 
     /* 为文章列出页卡片在小屏幕的观感体验优化 */

--- a/content/templates/default/echo_log.php
+++ b/content/templates/default/echo_log.php
@@ -7,9 +7,9 @@ if (!defined('EMLOG_ROOT')) {
 }
 ?>
 
-<main class="container log-con">
+<article class="container log-con">
     <span class="back-top mh" onclick="history.go(-1);">&laquo;</span>
-    <header class="log-title"><?php topflg($top) ?><?= $log_title ?></header>
+    <h1 class="log-title"><?php topflg($top) ?><?= $log_title ?></h1>
     <p class="date">
         <b>时间：</b><?= date('Y-n-j', $date) ?>&nbsp;&nbsp;&nbsp;&nbsp;
         <b>作者：</b><?php blog_author($author) ?>&nbsp;&nbsp;&nbsp;&nbsp;
@@ -19,7 +19,7 @@ if (!defined('EMLOG_ROOT')) {
 
     </p>
     <hr class="bottom-5"/>
-    <article class="markdown" id="emlogEchoLog"><?= $log_content ?></article>
+    <div class="markdown" id="emlogEchoLog"><?= $log_content ?></div>
     <p class="top-5"><?php blog_tag($logid) ?></p>
 
 	<?php doAction('log_related', $logData) ?>
@@ -30,6 +30,6 @@ if (!defined('EMLOG_ROOT')) {
 	<?php blog_comments($comments) ?>
 
     <div style="clear:both;"></div>
-</main>
+</article>
 
 <?php include View::getView('footer') ?>

--- a/content/templates/default/footer.php
+++ b/content/templates/default/footer.php
@@ -6,17 +6,17 @@ if (!defined('EMLOG_ROOT')) {
 	exit('error!');
 }
 ?>
-<footer>
-    <div class="container">
-        <p class="text-center">
-            <a href="https://beian.miit.gov.cn/" target="_blank"><?= $icp ?></a><br>
-			<?= $footer_info ?>
-			<?php doAction('index_footer') ?>
-        </p>
-    </div>
-</footer>
+    <footer>
+        <div class="container">
+            <p class="text-center">
+                <a href="https://beian.miit.gov.cn/" target="_blank"><?= $icp ?></a><br>
+                <?= $footer_info ?>
+                <?php doAction('index_footer') ?>
+            </p>
+        </div>
+    </footer>
+    <script src="<?= TEMPLATE_URL ?>js/common_tpl.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
+    <script src="<?= TEMPLATE_URL ?>js/zoom.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
 </body>
-<script src="<?= TEMPLATE_URL ?>js/common_tpl.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
-<script src="<?= TEMPLATE_URL ?>js/zoom.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
 </html>
  

--- a/content/templates/default/header.php
+++ b/content/templates/default/header.php
@@ -21,7 +21,6 @@ require_once View::getView('module');
     <meta name="description" content="<?= $site_description ?>"/>
     <base href="<?= BLOG_URL ?>"/>
     <link rel="shortcut icon" href="<?= BLOG_URL ?>favicon.ico"/>
-    <link rel="bookmark" href="<?= BLOG_URL ?>favicon.ico" type="image/x-icon" 　/>
     <link rel="alternate" title="RSS" href="<?= BLOG_URL ?>rss.php" type="application/rss+xml"/>
     <link href="<?= TEMPLATE_URL ?>css/style.css?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>" rel="stylesheet" type="text/css"/>
     <link href="<?= TEMPLATE_URL ?>css/markdown.css?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>" rel="stylesheet" type="text/css"/>
@@ -50,3 +49,4 @@ require_once View::getView('module');
 
     </div>
 </nav>
+

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -300,10 +300,9 @@ $(document).ready(function(){
 
   $('#comment_submit[type="button"], #close-modal').click(function () {
     myBlog.comSubmitTip('judge')
-    if (myBlog.comSubmitTip()) {  // 在显示模态框前，先校验一下评论区内容
+    if (myBlog.comSubmitTip()) {  // 在显示评论的验证码模态框前，先校验一下评论区内容
       myBlog.viewModal()
     }
-    
   }),
 
   $(".form-control").blur(function () {

--- a/content/templates/default/log_list.php
+++ b/content/templates/default/log_list.php
@@ -25,7 +25,7 @@ if (!defined('EMLOG_ROOT')) {
 								<?php topflg($value['top'], $value['sortop'], isset($sortid) ? $sortid : '') ?>
                                 <?php bloglist_sort($value['logid']) ?>
                             </h3>
-                            <summary class="loglist-content markdown"><?= $value['log_description'] ?></summary>
+                            <div class="loglist-content markdown"><?= $value['log_description'] ?></div>
                             <div class="loglist-tag"><?php blog_tag($value['logid']) ?></div>
                         </div>
                         <hr class="list-line"/>
@@ -45,9 +45,9 @@ if (!defined('EMLOG_ROOT')) {
 				?>
                 <p>抱歉，暂时还没有内容。</p>
 			<?php endif ?>
-            <ul class="pagination bottom-5">
+            <div class="pagination bottom-5">
 				<?= $page_url ?>
-            </ul>
+            </div>
         </div>
 		<?php include View::getView('side') ?>
     </div>

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -38,15 +38,15 @@ function widget_blogger($title) {
         <div class="widget-title">
             <h3><?= $title ?></h3>
         </div>
-        <ul class="unstyle-li bloggerinfo">
+        <div class="unstyle-li bloggerinfo"> 
+        <?php if (!empty($user_cache[1]['photo']['src'])): ?>
             <div>
-				<?php if (!empty($user_cache[1]['photo']['src'])): ?>
-                    <img class='bloggerinfo-img' src="<?= BLOG_URL . $user_cache[1]['photo']['src'] ?>" alt="blogger"/>
-				<?php endif ?>
+                <img class='bloggerinfo-img' src="<?= BLOG_URL . $user_cache[1]['photo']['src'] ?>" alt="blogger"/>
             </div>
-            <p class='bloginfo-name'><b><?= $name ?></b></p>
-            <p class='bloginfo-cache'> <?= $user_cache[1]['des'] ?></p>
-        </ul>
+        <?php endif ?>
+            <div class='bloginfo-name'><b><?= $name ?></b></div>
+            <div class='bloginfo-descript'><?= $user_cache[1]['des'] ?></div>
+        </div>
     </div>
 <?php } ?>
 <?php
@@ -58,10 +58,10 @@ function widget_calendar($title) { ?>
         <div class="widget-title m">
             <h3><?= $title ?></h3>
         </div>
-        <ul class="unstyle-li">
+        <div class="unstyle-li">
             <div id="calendar"></div>
             <script>sendinfo('<?= Calendar::url() ?>', 'calendar');</script>
-        </ul>
+        </div>
     </div>
 <?php } ?>
 <?php
@@ -75,12 +75,12 @@ function widget_tag($title) {
         <div class="widget-title m">
             <h3><?= $title ?></h3>
         </div>
-        <ul class="unstyle-li tag-container">
+        <div class="unstyle-li tag-container">
 			<?php foreach ($tag_cache as $value): ?>
                 <span style="font-size:<?= $value['fontsize'] ?>pt; line-height:30px;">
             <a href="<?= Url::tag($value['tagurl']) ?>" title="<?= $value['usenum'] ?> 篇文章" class='tags-side'><?= $value['tagname'] ?></a></span>
 			<?php endforeach ?>
-        </ul>
+        </div>
     </div>
 <?php } ?>
 <?php
@@ -139,9 +139,9 @@ function widget_newcomm($title) {
 			foreach ($com_cache as $value):
 				$url = Url::comment($value['gid'], $value['page'], $value['cid']);
 				?>
-                <li class='comment-info' id="side-comment">
+                <li class="comment-info">
                 <?php if ($isGravatar == 'y'): ?>
-                    <img class='comment-info_img' src="<?= getGravatar($value['mail']) ?>"/>
+                    <img class='comment-info_img' src="<?= getGravatar($value['mail']) ?>" alt="commentator" />
                 <?php endif ?>
                     <span class='comm-lates-name'><?= $value['name'] ?></span>
                     <span class='logcom-latest-time'><?= smartDate($value['date']) ?></span><br/>
@@ -199,12 +199,12 @@ function widget_search($title) { ?>
         <div class="widget-title">
             <h3><?= $title ?></h3>
         </div>
-        <ul class="unstyle-li" style="text-align: center;">
+        <div class="unstyle-li" style="text-align: center;">
             <form name="keyform" method="get" action="<?= BLOG_URL ?>index.php">
                 <input name="keyword" class="search form-control" autocomplete="off" type="text"/>
                 <input type="submit" value="搜索">
             </form>
-        </ul>
+        </div>
     </div>
 <?php } ?>
 <?php
@@ -270,7 +270,7 @@ function blog_navi() {
 				<?php if (!empty($value['children']) || !empty($value['childnavi'])) : ?>
                 <li class="list-item list-menu">
 					<?php if (!empty($value['children'])): ?>
-                        <a class='nav-link has-down' id="nav_link""  <?= $newtab ?>><?= $value['naviname'] ?> <b class="caret"></b></a>
+                        <a class="nav-link has-down" id="nav_link" <?= $newtab ?>><?= $value['naviname'] ?> <b class="caret"></b></a>
                         <ul class="dropdown-menus">
 							<?php foreach ($value['children'] as $row) {
 								echo '<li class="list-item list-menu"><a class="nav-link" href="' . Url::sort($row['sid']) . '">' . $row['sortname'] . '</a></li>';
@@ -342,9 +342,9 @@ function bloglist_sort($blogid) {
 	$log_cache_sort = $CACHE->readCache('logsort');
 	?>
 	<?php if (!empty($log_cache_sort[$blogid])) { ?>
-        <div class="loglist-sort" >
+        <span class="loglist-sort" >
             <a href="<?= Url::sort($log_cache_sort[$blogid]['id']) ?>" title="分类：<?= $log_cache_sort[$blogid]['name'] ?>"><?= $log_cache_sort[$blogid]['name'] ?></a>
-        </div>
+        </span>
     <?php }
 } ?>
 <?php
@@ -410,8 +410,6 @@ function neighbor_log($neighborLog) {
 function blog_comments($comments) {
 	extract($comments);
 	if ($commentStacks): ?>
-    
-        <a name="comments"></a>
         <div class="comment-header"><b>评论：</b></div>
 	<?php endif ?>
 	<?php
@@ -422,7 +420,6 @@ function blog_comments($comments) {
 		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
 		?>
         <div class="comment" id="comment-<?= $comment['cid'] ?>">
-            <a name="<?= $comment['cid'] ?>"></a>
 			<?php if ($isGravatar == 'y'): ?>
                 <div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>"/></div>
             <div class="comment-infos">
@@ -456,9 +453,8 @@ function blog_comments_children($comments, $children) {
 		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
 		?>
         <div class="comment comment-children" id="comment-<?= $comment['cid'] ?>">
-            <a name="<?= $comment['cid'] ?>"></a>
 			<?php if ($isGravatar == 'y'): ?>
-            <div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>"/></div>
+            <div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>" alt="commentator" /></div>
             <div class="comment-infos">
                 <div class="arrow"></div>
                 <b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
@@ -486,13 +482,10 @@ function blog_comments_children($comments, $children) {
  */
 function blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allow_remark) {
 	$isNeedChinese = Option::get('comment_needchinese');
-
 	if ($allow_remark == 'y'): ?>
         <div id="comment-place">
             <div class="comment-post" id="comment-post">
                 <div class="cancel-reply" id="cancel-reply" style="display:none"><a>取消回复</a></div>
-                <p class="comment-header">
-                    <a name="respond"></a><br></p>
                 <form class="commentform" method="post" name="commentform" action="<?= BLOG_URL ?>index.php?action=addcom" id="commentform"
                       is-chinese="<?= $isNeedChinese ?>">
                     <input type="hidden" name="gid" value="<?= $logid ?>"/>
@@ -534,7 +527,7 @@ function blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allo
                         </div>
                         <!-- 验证窗口(end) -->
 					<?php } ?>
-                    <input type="hidden" name="pid" id="comment-pid" value="0" size="22" tabindex="1"/>
+                    <input type="hidden" name="pid" id="comment-pid" value="0" tabindex="1"/>
                 </form>
             </div>
         </div>

--- a/content/templates/default/page.php
+++ b/content/templates/default/page.php
@@ -7,13 +7,13 @@ if (!defined('EMLOG_ROOT')) {
 }
 ?>
 
-<main class="container">
+<article class="container">
     <div class="row">
         <div class="column-big log-con " id="page">
-            <header class="page-title"><?= $log_title ?></header>
-            <article class="markdown">
+            <h1 class="page-title"><?= $log_title ?></h1>
+            <div class="markdown">
                 <?= $log_content ?>
-            </article>
+            </div>
 		    <?php blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allow_remark) ?>
             <?php blog_comments($comments) ?>
         </div>
@@ -21,7 +21,7 @@ if (!defined('EMLOG_ROOT')) {
 		include View::getView('side');
 		?>
     </div>
-</main>
+</article>
 <?php
 include View::getView('footer');
 ?>

--- a/content/templates/default/side.php
+++ b/content/templates/default/side.php
@@ -6,7 +6,7 @@ if (!defined('EMLOG_ROOT')) {
 	exit('error!');
 }
 ?>
-<asider class="column-small side-bar">
+<div class="column-small side-bar">
 	<?php
 	$widgets = !empty($options_cache['widgets1']) ? unserialize($options_cache['widgets1']) : array();
 	doAction('diff_side');
@@ -28,5 +28,5 @@ if (!defined('EMLOG_ROOT')) {
 		}
 	}
 	?>
-</asider>
+</div>
  


### PR DESCRIPTION
前台:
1. 修正代码使其完全符合 W3C 验证器
2. 边栏”标签“的边框删去

后台：
1. 大屏情况下，顶部的白色菜单栏高度与左边栏的水平线对齐
2. 顶部的白色菜单栏增加了轻微的透明磨砂效果，以削弱空间紧迫感
3. 编辑器初步增加了使用帮助的图标，向用户提供 markdown 语法帮助、说明一些快捷键