### PR TITLE
Update setting_mail.php and setting.php

### DIFF
--- a/admin/setting.php
+++ b/admin/setting.php
@@ -265,6 +265,7 @@ if ($action == 'mail') {
 	$smtp_pw = $options_cache['smtp_pw'] ?? '';
 	$smtp_server = $options_cache['smtp_server'] ?? '';
 	$smtp_port = $options_cache['smtp_port'] ?? '';
+	$smtp_ssl = $options_cache['smtp_ssl'] ?? '';
 
 	include View::getAdmView('header');
 	require_once(View::getAdmView('setting_mail'));
@@ -280,6 +281,7 @@ if ($action == 'mail_save') {
 		'smtp_pw'     => isset($_POST['smtp_pw']) ? addslashes($_POST['smtp_pw']) : '',
 		'smtp_server' => isset($_POST['smtp_server']) ? addslashes($_POST['smtp_server']) : '',
 		'smtp_port'   => isset($_POST['smtp_port']) ? (int)$_POST['smtp_port'] : '',
+		'smtp_ssl'   => isset($_POST['smtp_ssl']) ? addslashes($_POST['smtp_ssl']) : '',
 	];
 	foreach ($data as $key => $val) {
 		Option::updateOption($key, $val);
@@ -294,6 +296,7 @@ if ($action == 'mail_test') {
 		'smtp_pw'     => isset($_POST['smtp_pw']) ? addslashes($_POST['smtp_pw']) : '',
 		'smtp_server' => isset($_POST['smtp_server']) ? addslashes($_POST['smtp_server']) : '',
 		'smtp_port'   => isset($_POST['smtp_port']) ? (int)$_POST['smtp_port'] : '',
+		'smtp_ssl'   => isset($_POST['smtp_ssl']) ? addslashes($_POST['smtp_ssl']) : '',
 		'testTo'      => $_POST['testTo'] ?? '',
 	];
 
@@ -305,7 +308,7 @@ if ($action == 'mail_test') {
 	$mail->IsSMTP();                                       // SMTP 使用smtp鉴权方式发送邮件
 	$mail->CharSet = 'UTF-8';                              // 字符编码
 	$mail->SMTPAuth = true;                                // 开启认证
-	$mail->SMTPSecure = 'ssl';                             // 设置使用 ssl 加密方式登录鉴权
+	$mail->SMTPSecure = $data["smtp_ssl"];                 // 设置加密方式登录鉴权,如 SSL 或者 STARTTLS 等
 	$mail->Port = $data["smtp_port"];                      // 端口
 	$mail->Host = $data["smtp_server"];                    // STMP 服务器地址
 	$mail->Username = $data["smtp_mail"];                  // 邮箱账号

--- a/admin/views/setting_mail.php
+++ b/admin/views/setting_mail.php
@@ -36,6 +36,10 @@
                 <label>端口</label>
                 <input class="form-control" value="<?= $smtp_port ?>" name="smtp_port" required>
             </div>
+	    <div class="form-group">
+                <label>协议</label>
+                <input class="form-control" value="<?= $smtp_ssl ?>" name="smtp_ssl" required>
+            </div>
             <div class="form-group">
                 <input name="token" id="token" value="<?= LoginAuth::genToken() ?>" type="hidden"/>
                 <input type="submit" value="保存设置" class="btn btn-sm btn-success"/>
@@ -47,6 +51,8 @@
                 SMTP密码：见QQ邮箱顶部设置-> 账户 -> 开启IMAP/SMTP服务 -> 生成授权码（即为SMTP密码）<br>
                 SMTP服务器：smtp.qq.com<br>
                 端口：465 (只支持 SSL 端口)
+                <br>
+		常见SMTP加密协议为: SSL(465端口 QQ邮箱，网易邮箱等),STARTTLS(587端口，Outlook 邮箱)
                 <br>
             </div>
             <!-- 设置接收邮箱的模态框 -->


### PR DESCRIPTION
upgrade SMTPSecure fix not support STARTTLS method like Outlook mail smtp
修复原有的邮件通知不支持 Outlook 邮箱的 587端口的STARTTLS加密方式。
上述修改我已经自己测试是 OK 的，那多或者其他人可以测试下。
也可以只改动 setting.php 将 https://github.com/emlog/emlog/blob/ee8f3c5b93ee9000294ec92b7ae90bdee5bdd5b1/admin/setting.php#L308 注释掉，改成如下这样，增加一行判断也可以：
```php
//$mail->SMTPSecure = 'ssl';                             // 设置使用 ssl 加密方式登录鉴权
if ($data["smtp_port"] == '587') $mail->SMTPSecure = 'STARTTLS';
```
不过这种方式不推荐 不够灵活。