### PR TITLE
修复编辑器表格多次点击的 bug

### DIFF
--- a/admin/editor.md/plugins/table-dialog/table-dialog.js
+++ b/admin/editor.md/plugins/table-dialog/table-dialog.js
@@ -67,7 +67,9 @@
 		exports.fn.tableDialog = function() {
 			var _this       = this;
 			var cm          = this.cm;
-			var editor      = this.editor;
+			/* 修改：更换对话框创建的位置 */
+			// var editor       = this.editor;
+			var editor       = $("#editor-md-dialog");
 			var settings    = this.settings;
 			var path        = settings.path + "../plugins/" + pluginName +"/";
 			var classPrefix = this.classPrefix;


### PR DESCRIPTION
此是之前，将编辑器的对话框工具定义在一个不被 后台 顶栏遮挡的地方后，遗留的小问题。

其他工具都已经一一被解决，但不慎忘掉还有一个表格没解决￣□￣｜｜。解决方式就是重新定义程序中 editor 的元素。

还是一样的配方。