### PR TITLE
修复图片相关的两个问题

### DIFF
--- a/admin/views/js/common.js
+++ b/admin/views/js/common.js
@@ -435,7 +435,7 @@ function imgPasteExpand(thisEditor) {
                     console.log('获取结果成功！');
                     imgUrl = data.match(/[a-zA-z]+:\/[^\s\"\']*/g)[0];
                     thumbImgUrl = data.match(/[a-zA-z]+:\/[^\s\"\']*/g)[1];
-                    replaceByNum(`[![](${imgUrl})](${thumbImgUrl})`, 10);  // 这里的数字 10 对应着’上传中...100%‘是10个字符
+                    replaceByNum(`[![](${thumbImgUrl})](${imgUrl})`, 10);  // 这里的数字 10 对应着’上传中...100%‘是10个字符
                 })
             }, error: function (result) {
                 alert('上传失败,图片类型错误或网络错误');

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -24,7 +24,7 @@ var myBlog = {
             let $this = $(".markdown img:eq(" + num + ")")
             let sourceSrc = $(".markdown img:eq(" + num + ")").parent().attr('href')
 
-            if (sourceSrc.match(/\.(jpeg|jpg|gif|png)$/i) == null) {
+            if (typeof sourceSrc == "undefined" || sourceSrc.match(/\.(jpeg|jpg|gif|png)$/i) == null) {
                 continue
             }
 


### PR DESCRIPTION
前台

1. 添加了图片判断 undefined。如果文章中某个图片不存在 <a> 标签，那么 js 会报错

后台

1. 调换了粘贴图片时，原图和略缩图的位置。以前，粘贴图片会发生图片在前台默认显示原图，但点击后是略缩图的情况。
