### PR TITLE
对自带模版的细节优化

### DIFF
--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -186,7 +186,7 @@ footer .copyright {
 /* 博客头部属性的配置
 ---------------------------------------------------*/
 .blog-header {
-	margin-bottom: 2.4rem;
+	margin-bottom: 2.3rem;
 	background: #ffffff; /* 背景颜色颜色白色 */
 	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1) /* 阴影 */
 }
@@ -255,7 +255,7 @@ footer .copyright {
     .blog-header-subtitle {
         padding-top: 60px;
         left: 17px;
-        top: -11px
+        top: -9px
     }
 	/* 仅在小屏幕上显示切换菜单边框和切换菜单 */
 	.blog-header-toggle {
@@ -465,7 +465,7 @@ footer .copyright {
     font-weight: 100 !important
 }
 .calendar {
-    margin-bottom: -25px;
+    margin-bottom: -10px;
     width: 100%
 }
 .calendar td {
@@ -780,7 +780,7 @@ footer .copyright {
 .card-title {
     margin-bottom: 30px
 }
-/* 文章条目中的置顶图案，采用base64 */
+/* 文章条目中的置顶图案 */
 .log-topflg {
     user-select: none;
     display: inline-block;
@@ -998,8 +998,8 @@ footer .copyright {
     margin-left: -90px;
     position: absolute;
     top: 151px;
-    border: 1px solid #e6e6e6;
-    color: #e6e6e6;
+    border: 1px solid #dcdcdd;
+    color: #dcdcdd;
     border-radius: 50%;
     cursor: pointer
 }
@@ -1094,7 +1094,9 @@ footer .copyright {
 /* 网页足部
 ---------------------------------------------------*/
 .text-center {
-    text-align: center !important
+        line-height: 2;
+    margin-block: 30px;
+    text-align: center !important;
 }
 
 /* 图片放大
@@ -1211,7 +1213,7 @@ img.zoom-img {
         margin: -2px;
         padding-left: 2px
     }
-	/* 方便在中、小屏幕隐藏元素的class */
+	/* 方便在中、小屏幕隐藏元素的 class */
     .mh {
         display: none
     }

--- a/content/templates/default/footer.php
+++ b/content/templates/default/footer.php
@@ -9,7 +9,11 @@ if (!defined('EMLOG_ROOT')) {
     <footer>
         <div class="container">
             <p class="text-center">
-                <a href="https://beian.miit.gov.cn/" target="_blank"><?= $icp ?></a><br>
+                <?php
+                    if(!empty($icp)){
+                        echo '<div><a href="https://beian.miit.gov.cn/" target="_blank">'.$icp.'</a></div>';
+                    }
+                ?>
                 <?= $footer_info ?>
                 <?php doAction('index_footer') ?>
             </p>


### PR DESCRIPTION
1. [修复在图片多的文章里，toc 定位出错的问题](https://github.com/emlog/emlog/commit/94c65202dda61e9131e95bfc7c91d80ddac96dd5)

之前，如果文章中有大量图片的话，如何设置 toc 那么会出现目录定位不准的情况。现在解决了，方式是每隔 1.5s  重新更新一番 toc 内部的数据

2. [去除在不设置 ICP 备案下，默认模版足部多余的 a 标签](https://github.com/emlog/emlog/commit/5b581c20ccf37e54372440ff9f42e90f12fe5ea7)

由群友反馈的建议。如果不设置 ICP ，多一个 ICP 的空 a 标签确实很多余。