### PR TITLE
fix：修复编辑页面，插入图片略缩图和高清图链接不对，出错问题

### DIFF
--- a/include/model/media_model.php
+++ b/include/model/media_model.php
@@ -36,7 +36,7 @@ class Media_Model {
 				'addtime'       => date("Y - m - d H:i:s", $row['addtime']),
 				'aid'           => $row['aid'],
 				'filepath_thum' => $row['filepath'],
-				'filepath'      => str_replace("thum - ", '', $row['filepath']),
+				'filepath'      => str_replace("thum-", '', $row['filepath']),
 				'width'         => $row['width'],
 				'height'        => $row['height'],
 				'mimetype'      => $row['mimetype'],


### PR DESCRIPTION
问题根源是，这个地方的替换字符多了几个空格。

在之前

<img width="654" alt="image" src="https://user-images.githubusercontent.com/33373536/199174899-f4dc23b0-9152-4ddd-94fd-f9fa6db48a2c.png">

修改这里的代码后

<img width="596" alt="image" src="https://user-images.githubusercontent.com/33373536/199175141-ce63d6dc-72e0-45fc-9eb9-8102b18b6d8e.png">

另外，经过测试，七牛云插件启用后，不受影响。