### PR TITLE
feat：后台“页面”默认编辑器添加快捷键自动保存

### DIFF
--- a/admin/views/css/css-main.css
+++ b/admin/views/css/css-main.css
@@ -562,7 +562,6 @@ textarea {
 
     .container, .container-fluid, .container-sm, .container-md, .container-lg, .container-xl {
         width: auto;
-        padding-top: 80px;
         padding-left: 218px;
     }
 
@@ -574,7 +573,6 @@ textarea {
 
     .navbar {
         width: 100%;
-        position: fixed;
         z-index: 1;
         height: 50px;
         /* 顶部导航条磨砂效果 */

--- a/admin/views/js/common.js
+++ b/admin/views/js/common.js
@@ -194,7 +194,7 @@ function insert_cover(imgsrc) {
     $('#cover_rm').show();
 }
 
-// act: 1 auto save, 2 manual save：click save button to save,
+// act 参数各值的含义 1：定时自动保存。 2：普通保存。
 function autosave(act) {
     var nodeid = "as_logid";
     var timeout = 30000;
@@ -266,11 +266,34 @@ function autosave(act) {
             $("#savedf").attr("disabled", false).val(btname);
             $("#msg").html("网络或系统出现异常...保存可能失败").addClass("alert-danger");
             $('title').text('[保存失败] ' + titleText);
+            alert("保存失败，请备份内容和刷新页面后重试！")
         }
     });
     if (act == 1) {
         setTimeout("autosave(1)", timeout);
     }
+}
+
+// “页面”的 editor.md 编辑器 Ctrl + S 快捷键的自动保存动作
+function pagesave(){
+    document.addEventListener('keydown', function(e){  // 阻止自动保存产生的浏览器默认动作
+        if (e.keyCode == 83 && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey)){
+            e.preventDefault();
+        }
+    });
+
+    let url = "page.php?action=save";
+
+    $.post(url, $("#addlog").serialize(), function (data) {
+        let titleText = $('title').text();
+        $('title').text('[保存成功] ' + titleText);
+        setTimeout(function(){
+            $('title').text(titleText);
+        }, 2000);
+    }).fail(function(){
+        $('title').text('[保存失败] ' + $('title').text());
+        alert("保存失败！")
+    });
 }
 
 // toggle plugin
@@ -321,7 +344,7 @@ $(function () {
     });
 });
 
-// editor.md 的js钩子
+// editor.md 的 js 钩子
 var queue = new Array();
 var hooks = {
     addAction: function (hook, func) {

--- a/admin/views/page_create.php
+++ b/admin/views/page_create.php
@@ -139,15 +139,15 @@
                     if($(window).width() > 767){
                         this.watch();
                     }
-                    //添加Ctrl(Cmd)+S快捷键保存文章内容
-                    var articleSave = {
+                    //添加Ctrl(Cmd)+S快捷键保存页面内容
+                    var pageSave = {
                     "Ctrl-S": function(cm) {
-                    	autosave(2);
+                    	pagesave();
                     },
                     "Cmd-S": function(cm) {
-                    	autosave(2);
+                    	pagesave();
                     }};
-                    this.addKeyMap(articleSave);  
+                    this.addKeyMap(pageSave);  
             }
         });
         Editor.setToolbarAutoFixed(false);

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -1093,8 +1093,8 @@ footer .copyright {
 
 /* 网页足部
 ---------------------------------------------------*/
-.text-center {
-        line-height: 2;
+.footinfo {
+    line-height: 2;
     margin-block: 30px;
     text-align: center !important;
 }

--- a/content/templates/default/footer.php
+++ b/content/templates/default/footer.php
@@ -7,8 +7,7 @@ if (!defined('EMLOG_ROOT')) {
 }
 ?>
     <footer>
-        <div class="container">
-            <div class="text-center">
+        <div class="container footinfo">
                 <?php
                     if(!empty($icp)){
                         echo '<div><a href="https://beian.miit.gov.cn/" target="_blank">'.$icp.'</a></div>';
@@ -16,11 +15,9 @@ if (!defined('EMLOG_ROOT')) {
                 ?>
                 <?= $footer_info ?>
                 <?php doAction('index_footer') ?>
-            </div>
         </div>
     </footer>
     <script src="<?= TEMPLATE_URL ?>js/common_tpl.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
     <script src="<?= TEMPLATE_URL ?>js/zoom.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
 </body>
 </html>
- 


### PR DESCRIPTION
后台：

1. 后台顶部那个菜单栏，感觉把 position ：fixed 去掉后，操作体验一下子阔朗起来。感觉这样更好。
2. 页面编辑器之前是没有自动保存的，（因为还要为它定制个保存函数，懒），现在先简单加上了

前台：

3. 前台代码日常优化，没什么可说的