### PR TITLE
feat:页脚背景、后台编辑页面全局快捷键保存、优化前台体验

### DIFF
--- a/admin/views/article_write.php
+++ b/admin/views/article_write.php
@@ -245,16 +245,6 @@
                 if ($(window).width() > 767) {
                     this.watch();
                 }
-                //添加Ctrl(Cmd)+S快捷键保存文章内容
-                var articleSave = {
-                    "Ctrl-S": function (cm) {
-                        autosave(2);
-                    },
-                    "Cmd-S": function (cm) {
-                        autosave(2);
-                    }
-                };
-                this.addKeyMap(articleSave);
             }
         });
         Editor_summary = editormd("logexcerpt", {
@@ -372,4 +362,12 @@
             }
         });
     });
+
+    // 文章编辑界面全局快捷键 Ctrl（Cmd）+ S 保存内容
+    document.addEventListener('keydown', function(e){
+		if (e.keyCode == 83 && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey)){
+			e.preventDefault();
+            autosave(2);
+		}
+	});
 </script>

--- a/admin/views/css/css-main.css
+++ b/admin/views/css/css-main.css
@@ -597,7 +597,8 @@ textarea {
     }
 
     footer.sticky-footer {
-        background-color: unset !important;
+        margin-top: 2rem;
+        padding: 1rem 0;
     }
 
 }

--- a/admin/views/js/common.js
+++ b/admin/views/js/common.js
@@ -378,15 +378,6 @@ function imgPasteExpand(thisEditor) {
         thisEditor.config({readOnly: true,});
         thisEditor.config({readOnly: false,});
         thisEditor.setCursor({line: l, ch: c});
-
-        let saveHotKey = {  // 编辑器的 bug , 界面刷新后会删除自定义的热键，所以要重新设置
-            "Ctrl-S": function (cm) {
-                autosave(2);
-            }, "Cmd-S": function (cm) {
-                autosave(2);
-            }
-        };
-        thisEditor.addKeyMap(saveHotKey);
     }
 
     // 编辑器通过光标处位置前几位来替换文字

--- a/admin/views/page_create.php
+++ b/admin/views/page_create.php
@@ -134,20 +134,11 @@
             sequenceDiagram: false,
             syncScrolling : "single",
             onload: function () {
-                    hooks.doAction("page_loaded",this);
-                    //在大屏模式下，编辑器默认显示预览
-                    if($(window).width() > 767){
-                        this.watch();
-                    }
-                    //添加Ctrl(Cmd)+S快捷键保存页面内容
-                    var pageSave = {
-                    "Ctrl-S": function(cm) {
-                    	pagesave();
-                    },
-                    "Cmd-S": function(cm) {
-                    	pagesave();
-                    }};
-                    this.addKeyMap(pageSave);  
+                hooks.doAction("page_loaded",this);
+                //在大屏模式下，编辑器默认显示预览
+                if($(window).width() > 767){
+                    this.watch();
+                }
             }
         });
         Editor.setToolbarAutoFixed(false);
@@ -165,4 +156,12 @@
         if (e) e.returnValue = '离开页面提示';
         return '离开页面提示';
     }
+
+    // 页面编辑界面全局快捷键 Ctrl（Cmd）+ S 保存内容
+    document.addEventListener('keydown', function(e){
+		if (e.keyCode == 83 && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey)){
+			e.preventDefault();
+            pagesave();
+		}
+	});
 </script>

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -1184,13 +1184,20 @@ img.zoom-img {
     margin-bottom: 24px
 }
 
-/* 网站副标题的溢出（overflow）操作 
+/* 摘要的溢出（overflow）操作 
 ---------------------------------------------------*/
 .subtitle-overflow {
     max-width: 50%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis
+}
+
+/* 「归档」的样式 
+---------------------------------------------------*/
+.archive {
+    font-size: 16px;
+    padding: 4px
 }
 
 /* 一些适应各屏幕尺寸显示效果的样式
@@ -1400,7 +1407,7 @@ img.zoom-img {
         height: 30px;
         width: 30px;
     }
-    /* 网站副标题的溢出（overflow）操作 在 小屏幕上要截得多一点 */
+    /* 摘要的溢出（overflow）操作 在 小屏幕上要截得多一点 */
     .subtitle-overflow {
         max-width: 80%
     }

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -1197,7 +1197,8 @@ img.zoom-img {
 ---------------------------------------------------*/
 .archive {
     font-size: 16px;
-    padding: 4px
+    padding: 4px;
+    border-color: #ced4da
 }
 
 /* 一些适应各屏幕尺寸显示效果的样式

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -23,7 +23,7 @@ body {
     font-size: 16px;
     color: #5a5c69;
     background: #f5f5f6;
-    font-family: -apple-system, SF UI Text, Arial, PingFang SC, Hiragino Sans GB, Microsoft YaHei, WenQuanYi Micro Hei, sans-serif
+    font-family: helvetica neue,Helvetica,Arial,sans-serif
 }
 h1, h2, h3, h4, h5, h6 {
     margin-top: 0;
@@ -65,7 +65,8 @@ textarea {
     padding: 1rem 0.75rem
 }
 footer {
-    padding: 0px 50px;
+    margin-top: 30px;
+    background-color: white;
 } 
 footer .list-inline {
     margin: 0;
@@ -571,6 +572,9 @@ footer .copyright {
     .commentform {
         height: 250px
     }
+}
+#comment-place {
+    margin-top: 80px;
 }
 .comment-name {
     float: left;
@@ -1095,7 +1099,7 @@ footer .copyright {
 ---------------------------------------------------*/
 .footinfo {
     line-height: 2;
-    margin-block: 30px;
+    padding-block: 10px;
     text-align: center !important;
 }
 
@@ -1179,6 +1183,16 @@ img.zoom-img {
 #page{
     margin-bottom: 24px
 }
+
+/* 网站副标题的溢出（overflow）操作 
+---------------------------------------------------*/
+.subtitle-overflow {
+    max-width: 50%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
 /* 一些适应各屏幕尺寸显示效果的样式
 ---------------------------------------------------*/
 @media all and (max-width: 1200px) and (min-width: 992px) {
@@ -1303,7 +1317,6 @@ img.zoom-img {
 }
 /* 普通移动设备的显示样式 */
 @media all and (max-width: 577px) {
-
     .dropdown-menus .list-menu{
         padding-bottom : 0px
     }
@@ -1386,6 +1399,15 @@ img.zoom-img {
         margin: 6px 8px;
         height: 30px;
         width: 30px;
+    }
+    /* 网站副标题的溢出（overflow）操作 在 小屏幕上要截得多一点 */
+    .subtitle-overflow {
+        max-width: 80%
+    }
+    /* 网页顶部的下拉菜单在移动端的显示优化 */
+    .dropdown-menus .list-menu{
+        padding: 0px;
+        letter-spacing: 2px
     }
 }
 /* 为 toc 移动端设立的样式 */

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -1187,7 +1187,7 @@ img.zoom-img {
 /* 摘要的溢出（overflow）操作 
 ---------------------------------------------------*/
 .subtitle-overflow {
-    max-width: 50%;
+    max-width: 700px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis

--- a/content/templates/default/header.php
+++ b/content/templates/default/header.php
@@ -35,7 +35,7 @@ require_once View::getView('module');
 <nav class="blog-header">
     <div class="blog-header-c container">
         <a class="blog-header-title" href="<?= BLOG_URL ?>"><?= $blogname ?></a>
-        <div class="blog-header-subtitle subtitle-overflow"><?= $bloginfo ?></div>
+        <div class="blog-header-subtitle subtitle-overflow" title="<?= $bloginfo ?>"><?= $bloginfo ?></div>
         <div class="blog-header-toggle">
             <svg class="blogtoggle-icon">
                 <rect x="1" y="1" fill="#5F5F5F" width="26" height="1.6"/>

--- a/content/templates/default/header.php
+++ b/content/templates/default/header.php
@@ -35,7 +35,7 @@ require_once View::getView('module');
 <nav class="blog-header">
     <div class="blog-header-c container">
         <a class="blog-header-title" href="<?= BLOG_URL ?>"><?= $blogname ?></a>
-        <div class="blog-header-subtitle"><?= $bloginfo ?></div>
+        <div class="blog-header-subtitle subtitle-overflow"><?= $bloginfo ?></div>
         <div class="blog-header-toggle">
             <svg class="blogtoggle-icon">
                 <rect x="1" y="1" fill="#5F5F5F" width="26" height="1.6"/>

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -138,6 +138,11 @@ var myBlog = {
         $t.attr('src2', $t.attr('src'))
         $t.attr('src', $t.parent().attr('sourcesrc'))
     }, /**
+     * 归档下拉框的值被改变，跳转到相应日期文章的链接
+     */
+    jumpLink: function ($t) {
+        $(window).attr("location",$t.val())
+    },/**
     * toc 效果
     *
     * 启用 toc 目录方式: 在文章最开头写上'[toc]'或者'<!--[toc]-->',最好是单独一行
@@ -363,5 +368,9 @@ $(document).ready(function () {
 
     $(".markdown img").click(function () {
         myBlog.toggleImgSrc($(this))
+    }),
+
+    $("#archive").change(function () {
+        myBlog.jumpLink($(this))
     })
 })

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -334,34 +334,34 @@ $(document).ready(function () {
         myBlog.comReply($(this))
     }),
 
-        $(".cancel-reply").click(function () {
-            myBlog.cancelReply($(this))
-        }),
+    $(".cancel-reply").click(function () {
+        myBlog.cancelReply($(this))
+    }),
 
-        $(".blog-header-toggle").click(function () {
-            myBlog.navToggle($(this))
-        }),
+    $(".blog-header-toggle").click(function () {
+        myBlog.navToggle($(this))
+    }),
 
-        $(".has-down").mouseenter(function () {
-            myBlog.calMargin($(this))
-        }),
+    $(".has-down").mouseenter(function () {
+        myBlog.calMargin($(this))
+    }),
 
-        $("#captcha").click(function () {
-            myBlog.captchaRefresh($(this))
-        }),
+    $("#captcha").click(function () {
+        myBlog.captchaRefresh($(this))
+    }),
 
-        $('#comment_submit[type="button"], #close-modal').click(function () {
-            myBlog.comSubmitTip('judge')
-            if (myBlog.comSubmitTip()) {  // 在显示评论的验证码模态框前，先校验一下评论区内容
-                myBlog.viewModal()
-            }
-        }),
+    $('#comment_submit[type="button"], #close-modal').click(function () {
+        myBlog.comSubmitTip('judge')
+        if (myBlog.comSubmitTip()) {  // 在显示评论的验证码模态框前，先校验一下评论区内容
+            myBlog.viewModal()
+        }
+    }),
 
-        $(".form-control").blur(function () {
-            myBlog.comSubmitTip('judge')
-        }),
+    $(".form-control").blur(function () {
+        myBlog.comSubmitTip('judge')
+    }),
 
-        $(".markdown img").click(function () {
-            myBlog.toggleImgSrc($(this))
-        })
+    $(".markdown img").click(function () {
+        myBlog.toggleImgSrc($(this))
+    })
 })

--- a/content/templates/default/log_list.php
+++ b/content/templates/default/log_list.php
@@ -31,7 +31,10 @@ if (!defined('EMLOG_ROOT')) {
                         <hr class="list-line"/>
                         <div class="row info-row">
                             <div class="log-info">
-								<?php blog_author($value['author']) ?>&nbsp;发布于&nbsp;<?= date('Y-n-j', $value['date']) ?>&nbsp;<span class="mh"><?= date('H:i', $value['date']) ?></span>
+								<?php blog_author($value['author']) ?>&nbsp;发布于&nbsp;
+                                <?= date('Y-n-j', $value['date']) ?>&nbsp;
+                                <span class="mh"><?= date('H:i', $value['date']) ?></span>
+                                <?php editflg($value['logid'], $value['author']) ?>
                             </div>
                             <div class="log-count">
                                 <a href="<?= $value['log_url'] ?>#comments">评论(<?= $value['comnum'] ?>)&nbsp;</a>

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -314,7 +314,7 @@ function topflg($top, $sortop = 'n', $sortid = null) {
  * 文章查看页：编辑链接
  */
 function editflg($logid, $author) {
-	$editflg = User::haveEditPermission() || $author == UID ? '<a href="' . BLOG_URL . 'admin/article.php?action=edit&gid=' . $logid . '" target="_blank">&nbsp;&nbsp;&nbsp;编辑</a>' : '';
+	$editflg = User::haveEditPermission() || $author == UID ? '&nbsp;&nbsp;&nbsp;<a href="' . BLOG_URL . 'admin/article.php?action=edit&gid=' . $logid . '" target="_blank">编辑</a>' : '';
 	echo $editflg;
 }
 

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -220,11 +220,11 @@ function widget_archive($title) {
         <div class="widget-title m">
             <h3><?= $title ?></h3>
         </div>
-        <ul class="unstyle-li">
+        <select id="archive" class="archive">
 			<?php foreach ($record_cache as $value): ?>
-                <li><a href="<?= Url::record($value['date']) ?>"><?= $value['record'] ?>(<?= $value['lognum'] ?>)</a></li>
-			<?php endforeach ?>
-        </ul>
+                <option value="<?= Url::record($value['date']) ?>"><?= $value['record'] ?>&nbsp;(<?= $value['lognum'] ?>)</option>
+            <?php endforeach ?>
+        </select>
     </div>
 <?php } ?>
 <?php


### PR DESCRIPTION
后台：

 - 页脚加上了白色背景，（多少会有点好看吧）
 - 编辑页面（文章、页面）全局可使用快捷键 Ctrl（Cmd）+ S 来保存内容。（过去只能在光标在编辑器内，按快捷键才行）

前台：

 - 加上了白色页脚背景（比较，如果习惯了桌面网页的人，页头页脚的独特显示性还是很重要的）
 - 归档改为下拉框（内容特别多的话，这样会优雅一些）
 - 文章列出页，添加「编辑」快捷链接（方便编辑和修改文章）
 - 网页副标题的优化，在其内容过多时，截取一番。