### PR TITLE
fix:代码缩进调整，统一为大小为 4 的 TAB 制表符

### DIFF
--- a/content/templates/default/404.php
+++ b/content/templates/default/404.php
@@ -9,48 +9,48 @@ if (!defined('EMLOG_ROOT')) {
 <!doctype html>
 <html lang="zh-cn">
 <head>
-    <meta charset="utf-8">
-    <title>错误提示-页面未找到</title>
-    <style>
-        body {
-            background-color: #F7F7F7;
-            font-family: Arial;
-            font-size: 12px;
-            line-height: 150%
-        }
+	<meta charset="utf-8">
+	<title>错误提示-页面未找到</title>
+	<style>
+		body {
+			background-color: #F7F7F7;
+			font-family: Arial;
+			font-size: 12px;
+			line-height: 150%
+		}
 
-        .main {
-            background-color: #FFFFFF;
-            font-size: 12px;
-            color: #666666;
-            width: 650px;
-            margin: 60px auto 0px;
-            padding: 30px 10px;
-            box-shadow: 0 2px 8px 0 rgba(0, 0, 0, .02);
-            border-radius: 10px;
-            transition: box-shadow 0.4s
-        }
+		.main {
+			background-color: #FFFFFF;
+			font-size: 12px;
+			color: #666666;
+			width: 650px;
+			margin: 60px auto 0px;
+			padding: 30px 10px;
+			box-shadow: 0 2px 8px 0 rgba(0, 0, 0, .02);
+			border-radius: 10px;
+			transition: box-shadow 0.4s
+		}
 
-        .main p {
-            text-align: center;
-            font-weight: 600;
-            font-size: 2rem
-        }
+		.main p {
+			text-align: center;
+			font-weight: 600;
+			font-size: 2rem
+		}
 
-        .main p a {
-            border: 1px solid #ccc !important;
-            padding: 8px;
-            border-radius: 10px !important;
-            color: #929292;
-            font-size: initial;
-            text-decoration: none
-        }
-    </style>
+		.main p a {
+			border: 1px solid #ccc !important;
+			padding: 8px;
+			border-radius: 10px !important;
+			color: #929292;
+			font-size: initial;
+			text-decoration: none
+		}
+	</style>
 </head>
 <body>
 <div class="main">
-    <p>404 Not Found ！</p>
-    <p><a href="<?= BLOG_URL ?>">首页</a></p>
+	<p>404 Not Found ！</p>
+	<p><a href="<?= BLOG_URL ?>">首页</a></p>
 </div>
 </body>
 </html>

--- a/content/templates/default/css/markdown.css
+++ b/content/templates/default/css/markdown.css
@@ -2,164 +2,164 @@
  * markdown 输出样式
  */
 
-.markdown {
-    overflow-wrap: break-word;
-    text-align: justify
+ .markdown {
+	overflow-wrap: break-word;
+	text-align: justify
 }
 
 .markdown h1 {
-    font-size: 1.8rem !important;
-    margin-top: 1em;
-    margin-bottom: 16px;
-    font-weight: bold;
-    padding-bottom: 5px;
-    border-bottom: 1px solid #eee;
-    letter-spacing: 1px
+	font-size: 1.8rem !important;
+	margin-top: 1em;
+	margin-bottom: 16px;
+	font-weight: bold;
+	padding-bottom: 5px;
+	border-bottom: 1px solid #eee;
+	letter-spacing: 1px
 }
 
 .markdown h2 {
-    font-size: 1.5rem !important;
-    margin-top: 1em;
-    margin-bottom: 16px;
-    font-weight: bold;
-    padding-bottom: 5px;
-    border-bottom: 1px solid #eee;
-    letter-spacing: 1px
+	font-size: 1.5rem !important;
+	margin-top: 1em;
+	margin-bottom: 16px;
+	font-weight: bold;
+	padding-bottom: 5px;
+	border-bottom: 1px solid #eee;
+	letter-spacing: 1px
 }
 
 .markdown h3 {
-    font-size: 1.3rem !important;
-    line-height: 1.43;
-    font-weight: bold
+	font-size: 1.3rem !important;
+	line-height: 1.43;
+	font-weight: bold
 }
 
 .markdown h4 {
-    font-size: 1.2em !important;
-    margin-bottom: 16px;
-    font-weight: bold;
-    line-height: 1.4;
-    letter-spacing: 0.5px
+	font-size: 1.2em !important;
+	margin-bottom: 16px;
+	font-weight: bold;
+	line-height: 1.4;
+	letter-spacing: 0.5px
 }
 
 .markdown h5 {
-    font-size: 1rem !important;
-    margin-top: 1em;
-    margin-bottom: 16px;
-    font-weight: bold;
-    line-height: 1.4
+	font-size: 1rem !important;
+	margin-top: 1em;
+	margin-bottom: 16px;
+	font-weight: bold;
+	line-height: 1.4
 }
 
 .markdown h6 {
-    font-size: 1rem !important;
-    color: #777;
-    margin-top: 1em;
-    font-weight: bold;
-    line-height: 1.4;
-    margin-bottom: 16px
+	font-size: 1rem !important;
+	color: #777;
+	margin-top: 1em;
+	font-weight: bold;
+	line-height: 1.4;
+	margin-bottom: 16px
 }
 
 .markdown strong {
-    font-weight: bold;
-    font-size: 1rem !important
+	font-weight: bold;
+	font-size: 1rem !important
 }
 
 .markdown del {
-    text-decoration: line-through
+	text-decoration: line-through
 }
 
 .markdown a {
-    text-decoration: underline;
+	text-decoration: underline;
 }
 
 .markdown blockquote {
-    color: #666;
-    border-left: 4px solid #ddd;
-    padding-left: 20px;
-    margin-left: 0;
-    font-size: 14px;
-    font-style: italic
+	color: #666;
+	border-left: 4px solid #ddd;
+	padding-left: 20px;
+	margin-left: 0;
+	font-size: 14px;
+	font-style: italic
 }
 
 .markdown ul {
-    padding-left: 2em;
-    margin-bottom: 16px
+	padding-left: 2em;
+	margin-bottom: 16px
 }
 
 .markdown ol {
-    padding-left: 2em;
-    margin-bottom: 16px
+	padding-left: 2em;
+	margin-bottom: 16px
 }
 
 .markdown li {
-    font-size: 15px !important;
-    line-height: 2
+	font-size: 15px !important;
+	line-height: 2
 }
 
 .markdown hr {
-    height: 1px;
-    border: none;
-    border-top: 1px solid #ddd;
-    background: none
+	height: 1px;
+	border: none;
+	border-top: 1px solid #ddd;
+	background: none
 }
 
 .markdown pre.prettyprint {
-    padding: 10px;
-    border: 1px solid #ddd;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    line-height: 1.6
+	padding: 10px;
+	border: 1px solid #ddd;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	line-height: 1.6
 }
 
 .markdown table {
-    display: block;
-    width: 100%;
-    overflow: auto;
-    word-break: normal;
-    word-break: keep-all;
-    border-collapse: collapse;
-    margin-bottom: 16px
+	display: block;
+	width: 100%;
+	overflow: auto;
+	word-break: normal;
+	word-break: keep-all;
+	border-collapse: collapse;
+	margin-bottom: 16px
 }
 
 .markdown thead tr {
-    background-color: #F8F8F8
+	background-color: #F8F8F8
 }
 
 .markdown td {
-    padding: 6px 13px;
-    border: 1px solid #ddd
+	padding: 6px 13px;
+	border: 1px solid #ddd
 }
 
 .markdown th {
-    padding: 6px 13px;
-    border: 1px solid #ddd
+	padding: 6px 13px;
+	border: 1px solid #ddd
 }
 
 .markdown table tr:nth-child(even) {
-    background: #f8f8f8
+	background: #f8f8f8
 }
 
 .markdown code {
-    background: #f6f6f6;
-    border-radius: 3px;
-    font-size: 14px;
-    padding: 4px 5px;
-    margin-right: 4px
+	background: #f6f6f6;
+	border-radius: 3px;
+	font-size: 14px;
+	padding: 4px 5px;
+	margin-right: 4px
 }
 
 .markdown pre {
-    padding: 10px;
-    border: 1px solid #ddd;
-    background: #f6f6f6;
-    overflow: auto
+	padding: 10px;
+	border: 1px solid #ddd;
+	background: #f6f6f6;
+	overflow: auto
 }
 
 .markdown img {
-    display: block;
-    margin: auto;
-    box-sizing: border-box;
-    border: 0
+	display: block;
+	margin: auto;
+	box-sizing: border-box;
+	border: 0
 }
 
 .markdown hr {
-    margin: 7px 0 7px 0
+	margin: 7px 0 7px 0
 }

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -6,87 +6,87 @@
 ---------------------------------------------------*/
 /* 禁止页面溢出出现滚动条 */
 :root {
-    overflow-x: hidden
+	overflow-x: hidden
 }
 /* 一些变量 */
 * {
-    --marRadius : 8px /* 卡片圆角 */
+	--marRadius : 8px /* 卡片圆角 */
 }
 /* 定义所有元素的 width =（border+padding），方便后续计算 */
 * { 
-    box-sizing: border-box
+	box-sizing: border-box
 }
 /* 初始化 */
 body {
-    margin: 0;
-    line-height: 1.5;
-    font-size: 16px;
-    color: #5a5c69;
-    background: #f5f5f6;
-    font-family: helvetica neue,Helvetica,Arial,sans-serif
+	margin: 0;
+	line-height: 1.5;
+	font-size: 16px;
+	color: #5a5c69;
+	background: #f5f5f6;
+	font-family: helvetica neue,Helvetica,Arial,sans-serif
 }
 h1, h2, h3, h4, h5, h6 {
-    margin-top: 0;
-    font-weight: 400
+	margin-top: 0;
+	font-weight: 400
 }
 p {
-    line-height: 2;
-    margin: 30px 0
+	line-height: 2;
+	margin: 30px 0
 }
 a {
-    color: #333333;
-    transition: all 0.2s;
-    text-decoration: none 
+	color: #333333;
+	transition: all 0.2s;
+	text-decoration: none 
 }
 a:focus, a:hover {
-    color: #f6607d;
-    text-decoration: none
+	color: #f6607d;
+	text-decoration: none
 }
 img {
-    max-width: 100%
+	max-width: 100%
 }
 hr {
-    border: 0;
-    border-top: 1px solid rgba(0,0,0,.1)
+	border: 0;
+	border-top: 1px solid rgba(0,0,0,.1)
 }
 blockquote {
-    font-style: italic;
-    color: #868e96
+	font-style: italic;
+	color: #868e96
 }
 input,textarea {
-    font-family: inherit;
-    color: #495057;
-    outline:none
+	font-family: inherit;
+	color: #495057;
+	outline:none
 }
 input[type="submit"] {
-    cursor: pointer
+	cursor: pointer
 }
 textarea {
-    padding: 1rem 0.75rem
+	padding: 1rem 0.75rem
 }
 footer {
-    margin-top: 30px;
-    background-color: white;
+	margin-top: 60px;
+	background-color: white;
 } 
 footer .list-inline {
-    margin: 0;
-    padding: 0
+	margin: 0;
+	padding: 0
 }
 footer .copyright {
-    font-size: 14px;
-    margin-bottom: 0;
-    text-align: center
+	font-size: 14px;
+	margin-bottom: 0;
+	text-align: center
 }
 /* 无样式列表  */
 .unstyle-li {
-    padding-left: 0px;
-    list-style: none;
-    margin-block: 8px;
-    font-size: medium
+	padding-left: 0px;
+	list-style: none;
+	margin-block: 8px;
+	font-size: medium
 }
 /* 卡片属性。页面以卡片形式组成，这里直接配置，让整个页面的卡片有统一的内边距。 */
 .card-padding {
-    padding: 1.25rem
+	padding: 1.25rem
 }
 
 /* 布局
@@ -94,70 +94,70 @@ footer .copyright {
    列（col）则需要通过根据大小屏分别配置，这是网页最重要的地方，是整个网页的骨架
 ---------------------------------------------------*/
 .row {
-    display: flex;
-    flex-wrap: wrap;
+	display: flex;
+	flex-wrap: wrap;
 }
 /* 大屏下的列 */
 @media (min-width:768px)  {
-    .column-big {
-        padding-right: 10px;
-        flex: 0 0 66.666667%;
-        max-width: 66.666667%
-    }
-    /* 工具栏列 */
-    .column-small {
-        font-size: medium;
-        padding-left: 20px;
-        -ms-flex: 0 0 33.333333%;
-        flex: 0 0 33.333333%;
-        max-width: 33.333333%
-    }
-    /* 文章发布时间和文章阅读评论数这两列的配置 */
-    .info-row {
-        padding: 1rem !important
-    }
-    .log-info {
-        flex: 0 0 66.666667%;
-        max-width: 66.666667%
-    }
-    .log-count {
-        flex: 0 0 33.333333%;
-        max-width: 33.333333%;
-        text-align: right
-    }
+	.column-big {
+		padding-right: 10px;
+		flex: 0 0 66.666667%;
+		max-width: 66.666667%
+	}
+	/* 工具栏列 */
+	.column-small {
+		font-size: medium;
+		padding-left: 20px;
+		-ms-flex: 0 0 33.333333%;
+		flex: 0 0 33.333333%;
+		max-width: 33.333333%
+	}
+	/* 文章发布时间和文章阅读评论数这两列的配置 */
+	.info-row {
+		padding: 1rem !important
+	}
+	.log-info {
+		flex: 0 0 66.666667%;
+		max-width: 66.666667%
+	}
+	.log-count {
+		flex: 0 0 33.333333%;
+		max-width: 33.333333%;
+		text-align: right
+	}
 }
 /* 小屏下的列 */
 @media (max-width:767px) {
 
-    .column-big {
-        padding-right: 8px;
-        padding-left: 8px;
-        width:100%
-    }
-    /* 工具栏列 */
-    .column-small {
-        padding-right: 8px;
-        padding-left: 8px;
-        width:100%
-    }
-    /* 文章发布时间和文章阅读评论数两列的配置 */
-    .log-info {
-        flex: 0 0 60%;
-        max-width: 60%
-    }
-    .log-count {
-        white-space: nowrap;
-        flex: 0 0 40%;
-        max-width: 40%;
-        text-align: right
-    }
+	.column-big {
+		padding-right: 8px;
+		padding-left: 8px;
+		width:100%
+	}
+	/* 工具栏列 */
+	.column-small {
+		padding-right: 8px;
+		padding-left: 8px;
+		width:100%
+	}
+	/* 文章发布时间和文章阅读评论数两列的配置 */
+	.log-info {
+		flex: 0 0 60%;
+		max-width: 60%
+	}
+	.log-count {
+		white-space: nowrap;
+		flex: 0 0 40%;
+		max-width: 40%;
+		text-align: right
+	}
 }
 
 /* 最外层整体容器的响应式配置，即 container 配置
 ---------------------------------------------------*/
 .container{
-    width: 100%;
-    align-items: center;/* 网页容器在整个网页中垂直居中 */
+	width: 100%;
+	align-items: center;/* 网页容器在整个网页中垂直居中 */
 	margin-right: auto;
 	margin-left: auto
 }
@@ -168,12 +168,12 @@ footer .copyright {
 @media (min-width:1201px) {.container {max-width: 1140px}}
 /* 设置 container 在小型屏幕上的内外边距 ，使其更符合小型屏幕的观感体验 */
 @media (min-width:768px)  {
-    .container{
-        padding-right: 15px;
-        padding-left: 15px;
-        margin-right: auto;
-        margin-left: auto
-    }
+	.container{
+		padding-right: 15px;
+		padding-left: 15px;
+		margin-right: auto;
+		margin-left: auto
+	}
 }
 
 /* 在绝对定位情况下，主边栏的全宽(可供一些位于主边栏的难以计算宽度的对象使用)
@@ -187,18 +187,18 @@ footer .copyright {
 /* 博客页面底部（footer）没有空隙（即防止 footer 在页面中间位置出现的诡异现象）
 ---------------------------------------------------*/
 body {
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
 }
 .blog-header {
-    flex: 0 0 auto;
+	flex: 0 0 auto;
 }
 .blog-container {
-    flex: 1 0 auto;
+	flex: 1 0 auto;
 }
 .blog-footer {
-    flex: 0 0 auto;
+	flex: 0 0 auto;
 }
 
 /* 博客头部属性的配置
@@ -209,27 +209,27 @@ body {
 	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1) /* 阴影 */
 }
 .blog-header-c {
-    height: 71.63px;
-    display: flex;
-    justify-content: space-between /* 导航栏为主轴方向两端对齐，即大标题与导航两部分，一个向左靠齐，一个向右靠齐 */
+	height: 71.63px;
+	display: flex;
+	justify-content: space-between /* 导航栏为主轴方向两端对齐，即大标题与导航两部分，一个向左靠齐，一个向右靠齐 */
 }
 /* 博客标题和副标题 */
 .blog-header-title {
-    font-size: 26px;
-    z-index: 1
+	font-size: 26px;
+	z-index: 1
 }
 .blog-header-subtitle {
-    font-size: small;
-    letter-spacing: 0.2rem;
-    position: absolute;
-    padding-top: 48px;
-    z-index: 0
+	font-size: small;
+	letter-spacing: 0.2rem;
+	position: absolute;
+	padding-top: 48px;
+	z-index: 0
 }
 
 /* 导航链接的上下内边距（padding-block）要大，可使光标离开字符后一段距离依然能唤起子导航标签
  * 另外li标签的列表项标记为空 （list-style: none） */
 .nav-link {
-    padding: 1rem 0.5rem 1rem 0.5rem
+	padding: 1rem 0.5rem 1rem 0.5rem
 }
 .list-menu {
 	list-style: none
@@ -241,9 +241,9 @@ body {
 ---------------------------------------------------*/
 /* 大屏幕 */
 @media (min-width:768px)  {
-    .nav-list {
-        display: flex;
-        padding-block: 4.5px;
+	.nav-list {
+		display: flex;
+		padding-block: 4.5px;
 		text-align: center
 	}
 	/* 大屏幕列表样式 */
@@ -254,109 +254,109 @@ body {
 	.list-menu:last-child { 
 		border-bottom: unset
 	}
-    .blog-header-toggle {
-        display: none
-    }
+	.blog-header-toggle {
+		display: none
+	}
 }
 /* 小屏幕 */
 @media (max-width:767px)  {
 	.header {
-        padding: 0.6rem 1rem;
-        margin-bottom: 30px!important;
-        height:80px
-    }
-    .blog-header-title {
-        position: absolute;
-        left: 17px;
-        top: 18px
-    }
-    .blog-header-subtitle {
-        padding-top: 60px;
-        left: 17px;
-        top: -9px
-    }
+		padding: 0.6rem 1rem;
+		margin-bottom: 30px!important;
+		height:80px
+	}
+	.blog-header-title {
+		position: absolute;
+		left: 17px;
+		top: 18px
+	}
+	.blog-header-subtitle {
+		padding-top: 60px;
+		left: 17px;
+		top: -9px
+	}
 	/* 仅在小屏幕上显示切换菜单边框和切换菜单 */
 	.blog-header-toggle {
-        cursor: pointer;
-        position: absolute;
-        top: 25px;
-        right: 25px;
-    }
-    .blogtoggle-icon {
-        display: inline-block;
-        width: 28px;
-        height: 19px;
-        margin-top: -3px;
-        vertical-align: middle;
+		cursor: pointer;
+		position: absolute;
+		top: 25px;
+		right: 25px;
+	}
+	.blogtoggle-icon {
+		display: inline-block;
+		width: 28px;
+		height: 19px;
+		margin-top: -3px;
+		vertical-align: middle;
 	}
 	/* 小屏幕的导航变成下拉框 */
-    .blog-header-nav {
-        display: none;
-        z-index: 999;
-        position: absolute;
-        width: calc(100% - 4px);
-        background: white;
-        top: 72px;
-        left: 0
-    }
+	.blog-header-nav {
+		display: none;
+		z-index: 999;
+		position: absolute;
+		width: calc(100% - 4px);
+		background: white;
+		top: 72px;
+		left: 0
+	}
 	/* 小屏幕上头部的列表样式 */
-    .nav-list {
-        margin-top: 0px;
-        margin-bottom: 10px
-    }
-    .list-menu {
-        line-height: 28px;
-        width: 90%
-    }
+	.nav-list {
+		margin-top: 0px;
+		margin-bottom: 10px
+	}
+	.list-menu {
+		line-height: 28px;
+		width: 90%
+	}
 }
 
 /* 大屏幕下的下拉框样式，这里设置的透明度为0（opacity: 0.0;）。但小屏状态下
  * 没有隐藏，所以下面会在小屏部分，即767px及以下的部分对这个属性覆盖。 */
 .dropdown-menus {
-    background: white;
-    opacity: 0.0;
-    z-index: 4;
-    list-style: none;
-    margin-left: -26px;
-    position: absolute;
-    padding-left: 0px;
-    border: 1px solid #f1f1f1;
-    border-radius: 4px;
-    top: -3000px;
-    margin-bottom: -34px;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1)
+	background: white;
+	opacity: 0.0;
+	z-index: 4;
+	list-style: none;
+	margin-left: -26px;
+	position: absolute;
+	padding-left: 0px;
+	border: 1px solid #f1f1f1;
+	border-radius: 4px;
+	top: -3000px;
+	margin-bottom: -34px;
+	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1)
 }
 .dropdown-menus .list-menu{
-    padding: 6px
+	padding: 6px
 }
 
 /* 顶部菜单栏的小屏属性，“小屏”定义在767px及以下。当然这个也包含小屏的下拉框样式。 */
 @media all and (max-width: 767px) {
-    .nav-list {
-        text-align: left !important;
-        padding-left: 10%;
-        letter-spacing: 3px;
-        line-height: 17px
-    }
+	.nav-list {
+		text-align: left !important;
+		padding-left: 10%;
+		letter-spacing: 3px;
+		line-height: 17px
+	}
 	.dropdown-menus {
-        opacity: 1;
-        margin-left: 0px;
-        position: unset;
-        padding-left: 30px;
-        border: 0px solid #f1f1f1;
-        width: auto;
-        top: 0px;
-        margin-bottom: 0px;
-        box-shadow: 0 0 0 0 white;
-        font-size: smaller
-    }
+		opacity: 1;
+		margin-left: 0px;
+		position: unset;
+		padding-left: 30px;
+		border: 0px solid #f1f1f1;
+		width: auto;
+		top: 0px;
+		margin-bottom: 0px;
+		box-shadow: 0 0 0 0 white;
+		font-size: smaller
+	}
 }
 
 /* 下拉框的样式 */
 .list-menu:hover .dropdown-menus {
-    opacity: 0.95;
-    top: 56px;
-    transition: opacity 0.2s
+	opacity: 0.95;
+	top: 56px;
+	transition: opacity 0.2s
 }
 
 /* 列出文章（或文章条目）页
@@ -364,86 +364,86 @@ body {
  /* 卡片上的文章发布时间这部分的属性 */
 .info-row {
 	padding: 1rem;
-    padding-bottom: 8px !important
+	padding-bottom: 8px !important
 }
 
 /* 文章阅读页
 ---------------------------------------------------*/
  /* 文章作者、时间等信息下hr水平线的属性，设置margin-bottom为四级 */
 .bottom-5{
-    margin-bottom: 1.5rem !important
+	margin-bottom: 1.5rem !important
 }
 /* 标签的属性，设置margin-top为三级 */
 .top-5, .mtop-5 {
-    margin-top: 3rem !important
+	margin-top: 3rem !important
 }
 /* 验证码模态窗的配置 */
 .modal-dialog {
-    display:none;
-    background-color: white; 
-    border-radius: var(--marRadius);
-    border: 1px solid #dedede;
-    position: fixed;
-    z-index: 100;
-    /* 定位 */
-    top: 35%;
-    left: 50%;
-    transform: translate3d(-50%,-50%,0)
+	display:none;
+	background-color: white; 
+	border-radius: var(--marRadius);
+	border: 1px solid #dedede;
+	position: fixed;
+	z-index: 100;
+	/* 定位 */
+	top: 35%;
+	left: 50%;
+	transform: translate3d(-50%,-50%,0)
 }
 /* 验证码模态窗的按钮 */
 .btn {
-    cursor: pointer;
-    color: #848798;
-    background-color: white;
-    padding: 8px 11px;
-    font-weight: 800;
-    border-radius: var(--marRadius);
-    margin-block: 12px;
-    margin-inline: 17.5px;
-    border: 1px solid #dedede
+	cursor: pointer;
+	color: #848798;
+	background-color: white;
+	padding: 8px 11px;
+	font-weight: 800;
+	border-radius: var(--marRadius);
+	margin-block: 12px;
+	margin-inline: 17.5px;
+	border: 1px solid #dedede
 }
 .btn:hover {
-    color: #50525e
+	color: #50525e
 } 
 .modal-header {
-    text-align: center;
-    border-bottom: 0px;
-    width: 250px;
-    padding: 20px
+	text-align: center;
+	border-bottom: 0px;
+	width: 250px;
+	padding: 20px
 }
 .modal-content img {
-    float: left;
-    height: 32px;
-    margin-left: 20px;
-    margin-block: 30px
+	float: left;
+	height: 32px;
+	margin-left: 20px;
+	margin-block: 30px
 }
 .modal-content input[name="imgcode"] {
-    padding: 6px 8px !important;
-    margin-right: 20px;
-    margin-left: 8px;
-    text-align: left;
-    margin-block: 30px;
-    border: 1px solid #dedede
+	padding: 6px 8px !important;
+	margin-right: 20px;
+	margin-left: 8px;
+	text-align: left;
+	margin-block: 30px;
+	border: 1px solid #dedede
 }
 .modal-content .modal-footer {
-    padding: 10px;
-    text-align: center
+	padding: 10px;
+	text-align: center
 }
 /* 弹出验证码模态窗后，屏幕背景要锁住 */
 .lock-screen {
 	display:none;
-    z-index: 99;
-    position: fixed;
-    width: 100vw;
-    height: 100vh;
-    background-color: #2d2d2b;
-    top: 0;
-    left: 0;
-    opacity: 0.5
+	z-index: 99;
+	position: fixed;
+	width: 100vw;
+	height: 100vh;
+	background-color: #2d2d2b;
+	top: 0;
+	left: 0;
+	opacity: 0.5
 }
 /* 验证码的点击样式 */
 #captcha {
-    cursor: pointer
+	cursor: pointer
 }
 
 /* 禁止滚动 */
@@ -453,769 +453,769 @@ body {
    文章列出页的文章摘要卡片和边栏组件卡片的阴影和鼠标浮动后的阴影
 ---------------------------------------------------*/
 .shadow-theme {
-    box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.02);
-    border-radius: var(--marRadius);
-    background: #ffffff;
-    transition: box-shadow 0.4s
+	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.02);
+	border-radius: var(--marRadius);
+	background: #ffffff;
+	transition: box-shadow 0.4s
 }
 
 /* 日历样式
 ---------------------------------------------------*/
 /* 日历的加载样式，防止翻页造成太大的视觉变化 */
 .cal_loading {
-    margin-bottom: 243px
+	margin-bottom: 243px
 }
 #calendar {
-    color: #212529
+	color: #212529
 }
 #calendar a {
-    color: #000;
-    font-weight: bolder
+	color: #000;
+	font-weight: bolder
 }
 .calendartop {
-    letter-spacing: 3px;
-    width: 100%;
-    text-align: center;
-    margin-bottom: 10px;
-    color: #000
+	letter-spacing: 3px;
+	width: 100%;
+	text-align: center;
+	margin-bottom: 10px;
+	color: #000
 }
 .calendartop a {
-    font-weight: 100 !important
+	font-weight: 100 !important
 }
 .calendar {
-    margin-bottom: -10px;
-    width: 100%
+	margin-bottom: -10px;
+	width: 100%
 }
 .calendar td {
-    text-align: center;
-    padding: 1px 10px;
-    line-height: 1.6
+	text-align: center;
+	padding: 1px 10px;
+	line-height: 1.6
 }
 .calendar td a:link {
-    color: #886353;
-    text-decoration: none
+	color: #886353;
+	text-decoration: none
 }
 .calendar td a:hover {
-    color: #886353;
-    text-decoration: none
+	color: #886353;
+	text-decoration: none
 }
 .calendar tr {
-    height: 40px
+	height: 40px
 }
 .day {
-    color: #212529;
-    background: #eaeaea;
-    border-radius: var(--marRadius)
+	color: #212529;
+	background: #eaeaea;
+	border-radius: var(--marRadius)
 }
 .sun {
-    color: #333
+	color: #333
 }
 .week {
-    color: #333
+	color: #333
 }
 
 /* 侧边栏卡片样式
 ---------------------------------------------------*/
 /* 卡片的内边距和外边距 */
 .side-bar {
-    font-size: medium
+	font-size: medium
 }
 .side-bar .widget {
-    margin-bottom: 24px;
-    padding: 20px
+	margin-bottom: 24px;
+	padding: 20px
 }
 /* 边栏组件的标题 */
 .side-bar h3 {
-    position: relative;
-    font-size: 17px;
-    font-weight: 600;
-    margin-bottom: 20px
+	position: relative;
+	font-size: 17px;
+	font-weight: 600;
+	margin-bottom: 20px
 }
 .side-bar .widget li {
-    position: relative;
-    color: #6f6f6f;
-    line-height: 2
+	position: relative;
+	color: #6f6f6f;
+	line-height: 2
 }
 
 /* 分页按钮样式
 ---------------------------------------------------*/
 .pagination {
-    font-size: 14px;
-    padding: 10px;
-    text-align: center
+	font-size: 14px;
+	padding: 10px;
+	text-align: center
 }
 .pagination span {
-    padding: 5.5px 6px 3px 6px;
-    margin: 0 5px;
-    border-radius: 8px;
-    line-height: 3;
-    color: #858796
+	padding: 5.5px 6px 3px 6px;
+	margin: 0 5px;
+	border-radius: 8px;
+	line-height: 3;
+	color: #858796
 }
 .pagination a {
-    color: #c0bcbc;
-    padding: 5.5px 10px 3px 10px;
-    background: white;
-    margin: 0 5px;
-    line-height: 3;
-    border-radius: 8px
+	color: #c0bcbc;
+	padding: 5.5px 10px 3px 10px;
+	background: white;
+	margin: 0 5px;
+	line-height: 3;
+	border-radius: 8px
 }
 .pagination a:hover {
-    text-decoration: none
+	text-decoration: none
 }
 #pagenavi {
-    text-align: center;
-    font-size: 14px
+	text-align: center;
+	font-size: 14px
 }
 #pagenavi span {
-    padding: 4.5px 9px 4px 9px;
-    margin: 0 5px;
-    line-height: 3;
-    border-radius: var(--marRadius);
-    color: #000
+	padding: 4.5px 9px 4px 9px;
+	margin: 0 5px;
+	line-height: 3;
+	border-radius: var(--marRadius);
+	color: #000
 }
 #pagenavi a {
-    color: #c0bcbc;
-    padding: 4.5px 9px 4px 9px;
-    font-family: serif, monospace;
-    margin: 0 5px;
-    line-height: 3;
-    border-radius: var(--marRadius)
+	color: #c0bcbc;
+	padding: 4.5px 9px 4px 9px;
+	font-family: serif, monospace;
+	margin: 0 5px;
+	line-height: 3;
+	border-radius: var(--marRadius)
 }
 
 /* 评论样式
 ---------------------------------------------------*/
 /* 发表评论表单样式 */
 @media (min-width:768px)  {
-    .commentform {
-        height: 250px
-    }
+	.commentform {
+		height: 250px
+	}
 }
 #comment-place {
-    margin-top: 80px;
+	margin-top: 80px;
 }
 .comment-name {
-    float: left;
-    border-bottom-left-radius: 10px !important
+	float: left;
+	border-bottom-left-radius: 10px !important
 }
 .comment-mail {
-    float: left
+	float: left
 }
 .comment-url {
-    border-right: 1px #d6d6d6 solid !important;
-    border-bottom-right-radius: 10px !important
+	border-right: 1px #d6d6d6 solid !important;
+	border-bottom-right-radius: 10px !important
 }
 .form-controls {
-    display: block;
-    height: calc(1.5em + 0.75rem + 2px);
-    padding: 0.375rem 0.75rem;
-    font-size: 1rem;
-    font-weight: 400;
-    line-height: 1.5;
-    color: #495057;
-    background-color: #fff;
-    background-clip: padding-box;
-    border: 1px solid #ced4da;
-    border-radius: 0.25rem;
-    transition: border-color 0.15s ease-out, box-shadow 0.15s ease-in-out
+	display: block;
+	height: calc(1.5em + 0.75rem + 2px);
+	padding: 0.375rem 0.75rem;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.5;
+	color: #495057;
+	background-color: #fff;
+	background-clip: padding-box;
+	border: 1px solid #ced4da;
+	border-radius: 0.25rem;
+	transition: border-color 0.15s ease-out, box-shadow 0.15s ease-in-out
 }
 .comment-info {
-    width: auto
+	width: auto
 }
 .com_control {
-    display: block;
-    border-radius: 0px;
-    border: 1px #d6d6d6 solid;
-    border-right: 0px;
-    height: 50px
+	display: block;
+	border-radius: 0px;
+	border: 1px #d6d6d6 solid;
+	border-right: 0px;
+	height: 50px
 } 
 
 /* 评论处的输入框提示，居中、隐藏 */
 .com_control:focus::-webkit-input-placeholder{
-    color: rgba(255, 255, 255, 0)
+	color: rgba(255, 255, 255, 0)
 } 
 .com_control::-webkit-input-placeholder {
-    color: rgba(116, 116, 116, 0.336)
+	color: rgba(116, 116, 116, 0.336)
 }
 @media (min-width:578px) {
-    .com_control::-webkit-input-placeholder {
-        text-align: center
-    }
+	.com_control::-webkit-input-placeholder {
+		text-align: center
+	}
 }
 .comment-header {
-    margin-block: 30px;
-    height: 0
+	margin-block: 30px;
+	height: 0
 }
 .comment-post {
-    clear: both
+	clear: both
 }
 .comment-post p {
-    margin: 5px 0px
+	margin: 5px 0px
 }
 .comment-post .cancel-reply {
-    float: right;
-    cursor: pointer;
-    _cursor: hand;
-    padding-right: 10%
+	float: right;
+	cursor: pointer;
+	_cursor: hand;
+	padding-right: 10%
 }
 .comment-post .cancel-reply:hover {
-    text-decoration: underline
+	text-decoration: underline
 }
 .comment-post small {
-    font-size: 12px;
-    color: #999
+	font-size: 12px;
+	color: #999
 }
 .comment-post input {
-    padding: 7px 40px;
-    font-size: small;
-    color: #848797;
-    width: 33.3333334%
+	padding: 7px 40px;
+	font-size: small;
+	color: #848797;
+	width: 33.3333334%
 }
 .comment-post #comment {
-    width: 100%;
-    border: 1px #d6d6d6 solid;
-    font-size: small;
-    border-radius: var(--marRadius) 10px 0 0;
-    height: 130px;
-    resize: none
+	width: 100%;
+	border: 1px #d6d6d6 solid;
+	font-size: small;
+	border-radius: var(--marRadius) 10px 0 0;
+	height: 130px;
+	resize: none
 }
 .comment-post #comment_submit {
-    width: 84px;
-    height: 35px;
-    text-align: center;
-    font-size: 14px;
-    margin: 10px 0px;
-    float: right;
-    margin-right: 1px;
-    border-radius: 8px;
-    border: 1px solid #dedede;
-    padding: 7px 10px;
-    justify-content: center
+	width: 84px;
+	height: 35px;
+	text-align: center;
+	font-size: 14px;
+	margin: 10px 0px;
+	float: right;
+	margin-right: 1px;
+	border-radius: 8px;
+	border: 1px solid #dedede;
+	padding: 7px 10px;
+	justify-content: center
 }
 .comment-post #comment_submit:hover {
-    cursor: pointer;
-    color: #fff;
-    background-color: #007bff
+	cursor: pointer;
+	color: #fff;
+	background-color: #007bff
 }
 .comment-post .input {
-    width: 100px
+	width: 100px
 }
 .comment {
-    margin: 10px 0;
-    padding: 10px 0px;
-    font-size: medium;
-    border-bottom: 1px #f7f7f7 solid;
-    overflow: hidden;
-    color: #333
+	margin: 10px 0;
+	padding: 10px 0px;
+	font-size: medium;
+	border-bottom: 1px #f7f7f7 solid;
+	overflow: hidden;
+	color: #333
 }
 .comment span {
-    color: #ff7a15
+	color: #ff7a15
 }
 .comment .comment-time {
-    color: #999999;
-    display: inline;
-    font-size: 10px
+	color: #999999;
+	display: inline;
+	font-size: 10px
 }
 .comment .avatar {
-    float: left;
-    margin: 5px 4px
+	float: left;
+	margin: 5px 4px
 }
 .comment .comment-infos {
-    background: #f7f7f7;
-    padding: 12px;
-    padding-bottom: 5px;
-    border-radius: var(--marRadius);
-    margin-top: 9px;
-    margin-left: 58px
+	background: #f7f7f7;
+	padding: 12px;
+	padding-bottom: 5px;
+	border-radius: var(--marRadius);
+	margin-top: 9px;
+	margin-left: 58px
 }
 .comment .comment-infos-unGravatar {
-    padding: 5px
+	padding: 5px
 }
 .com-bottom {
-    margin-bottom: 80px;
+	margin-bottom: 80px;
 }
 /* 评论列表中指向评论者头像的箭头 */
 .arrow {
-    position: absolute;
-    margin-top: 3px;
-    margin-left: -34px;
-    border-width: 13px;
-    border-style: solid;
-    border-color: transparent #f7f7f7 transparent transparent
+	position: absolute;
+	margin-top: 3px;
+	margin-left: -34px;
+	border-width: 13px;
+	border-style: solid;
+	border-color: transparent #f7f7f7 transparent transparent
 }
 .comment .comment-content {
-    margin: 8px 0px 0px 0px;
-    word-break: break-word
+	margin: 8px 0px 0px 0px;
+	word-break: break-word
 }
 .comment .comment-reply {
-    float: right;
-    font-size: 12px;
-    cursor: pointer;
-    margin-top: -15px
+	float: right;
+	font-size: 12px;
+	cursor: pointer;
+	margin-top: -15px
 }
 .comment .comment-reply:hover {
-    text-decoration: underline
+	text-decoration: underline
 }
 .comment-children {
-    margin: 20px 10px 10px 20px;
-    clear: both;
-    border: none;
-    padding: 0
+	margin: 20px 10px 10px 20px;
+	clear: both;
+	border: none;
+	padding: 0
 }
 .comment .comment-post {
-    width: 90%;
-    margin: 15px auto
+	width: 90%;
+	margin: 15px auto
 }
 .comment-info {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    margin-top: -8px;
-    white-space: nowrap
+	text-overflow: ellipsis;
+	overflow: hidden;
+	margin-top: -8px;
+	white-space: nowrap
 }
 /* 边栏处的最新评论信息margin-top应该是0 */
 .unstyle-li .comment-info {
-    margin-top: 4px
+	margin-top: 4px
 }
 .cancel-reply {
-    font-size: large
+	font-size: large
 }
 /* 评论人的头像 */
 .avatar img {
-    margin-top: 9px;
-    margin-right: 4px;
-    border-radius: 50%
+	margin-top: 9px;
+	margin-right: 4px;
+	border-radius: 50%
 }
 .unstyle-li input[type="submit"] {
-    background-color: #313131;
-    color: #FFFFFF;
-    margin-left: -25px;
-    height: 39px;
-    width: 55px;
-    border: 0;
-    border-radius: 0 3px 3px 0;
-    padding: 0
+	background-color: #313131;
+	color: #FFFFFF;
+	margin-left: -25px;
+	height: 39px;
+	width: 55px;
+	border: 0;
+	border-radius: 0 3px 3px 0;
+	padding: 0
 }
 
 /*文章条目中的部分样式
 ---------------------------------------------------*/
 /* 文章条目的标题 */
 .card-title {
-    margin-bottom: 30px
+	margin-bottom: 30px
 }
 /* 文章条目中的置顶图案 */
 .log-topflg {
-    user-select: none;
-    display: inline-block;
-    position: relative;
-    height: 26px;
-    padding: 3px 4.5px;
-    bottom: 3.5px;
-    font-size: 14px;
-    margin-left: 8px;
-    cursor: default;
-    background-color: antiquewhite
+	user-select: none;
+	display: inline-block;
+	position: relative;
+	height: 26px;
+	padding: 3px 4.5px;
+	bottom: 3.5px;
+	font-size: 14px;
+	margin-left: 8px;
+	cursor: default;
+	background-color: antiquewhite
 }
 
 /* 文章内容页样式
 ---------------------------------------------------*/
 .log-con {
-    background-color: #ffffff;
-    border-radius: var(--marRadius);
-    max-width: 960px;
-    padding: 30px;
-    font-size: 16px;
-    height: fit-content;
-    letter-spacing: 0.5px
+	background-color: #ffffff;
+	border-radius: var(--marRadius);
+	max-width: 960px;
+	padding: 30px;
+	font-size: 16px;
+	height: fit-content;
+	letter-spacing: 0.5px
 }
 .log-con p {
-    margin-top: 0;
-    margin-bottom: 16px
+	margin-top: 0;
+	margin-bottom: 16px
 }
 .log-con .date {
-    margin-bottom: 0px
+	margin-bottom: 0px
 }
 .log-con .markdown {
-    margin-inline: 5px;
+	margin-inline: 5px;
 }
 .loglist-content h1 {
-    font-size: medium;
-    font-family: inherit;
-    letter-spacing: 0.5px;
-    margin: 0
+	font-size: medium;
+	font-family: inherit;
+	letter-spacing: 0.5px;
+	margin: 0
 }
 .loglist-content h2 {
-    font-size: medium;
-    font-family: inherit;
-    letter-spacing: 0.5px;
-    margin: 0
+	font-size: medium;
+	font-family: inherit;
+	letter-spacing: 0.5px;
+	margin: 0
 }
 .loglist-content h3 {
-    font-size: medium;
-    font-family: inherit;
-    letter-spacing: 0.5px;
-    margin: 0
+	font-size: medium;
+	font-family: inherit;
+	letter-spacing: 0.5px;
+	margin: 0
 }
 .loglist-content h4 {
-    font-size: medium;
-    font-family: inherit;
-    letter-spacing: 0.5px;
-    margin: 0
+	font-size: medium;
+	font-family: inherit;
+	letter-spacing: 0.5px;
+	margin: 0
 }
 .loglist-content h5 {
-    font-size: medium;
-    font-family: inherit;
-    letter-spacing: 0.5px;
-    margin: 0
+	font-size: medium;
+	font-family: inherit;
+	letter-spacing: 0.5px;
+	margin: 0
 }
 .loglist-content p {
-    font-size: medium;
-    font-family: inherit;
-    margin: 0
+	font-size: medium;
+	font-family: inherit;
+	margin: 0
 }
 /* 需要改名，侧边栏链接卡片的友情链接属性 */
 .no-margin-bottom {
-    font-size: medium;
-    padding-left: 10px
+	font-size: medium;
+	padding-left: 10px
 }
 /* 摘要内容部分 */
 .loglist-body {
-    margin-bottom: -22px;
-    font-size: small
+	margin-bottom: -22px;
+	font-size: small
 }
 .loglist-body p {
-    margin: 0 -6px 0 0
+	margin: 0 -6px 0 0
 }
 /* 文章标题和标签等 */
 .loglist-title {
-    font-size: x-large
+	font-size: x-large
 }
 .loglist-tag {
-    margin-top: 30px;
-    line-height: 2;
-    color: #000000
+	margin-top: 30px;
+	line-height: 2;
+	color: #000000
 }
 .loglist-tag a {
-    color: #929292
+	color: #929292
 }
 .loglist-cover {
-    width: 100%;
-    height: 205px;
-    border-radius: var(--marRadius) 10px 0 0
+	width: 100%;
+	height: 205px;
+	border-radius: var(--marRadius) 10px 0 0
 }
 .loglist-cover img {
-    position: absolute;
-    opacity: 0.8;
-    border-radius: var(--marRadius) 10px 0 0;
-    transition: all 0.4s;
-    clip: rect(50px,730px,250px,0px);
-    margin-top: -50px
+	position: absolute;
+	opacity: 0.8;
+	border-radius: var(--marRadius) 10px 0 0;
+	transition: all 0.4s;
+	clip: rect(50px,730px,250px,0px);
+	margin-top: -50px
 }
 .loglist-cover img:hover {
-    opacity: 0.7;
-    transform: scale(1.01);
-    clip: rect(50px,730px,250px,0px)
+	opacity: 0.7;
+	transform: scale(1.01);
+	clip: rect(50px,730px,250px,0px)
 }
 /* 文章分类 */
 .loglist-sort {
-    user-select: none;
-    display: inline-block;
-    position: relative;
-    margin-left: 10px;
-    bottom: 2px;
-    padding: 6px;
-    padding-bottom: 3px;
-    border: 1px solid #e8e8e8
+	user-select: none;
+	display: inline-block;
+	position: relative;
+	margin-left: 10px;
+	bottom: 2px;
+	padding: 6px;
+	padding-bottom: 3px;
+	border: 1px solid #e8e8e8
 }
-@media (max-width:415px) {.loglist-cover{ height: 160px;overflow: hidden}.loglist-cover img {position:unset;    width: 730px;}}
-@media (max-width:375px) {.loglist-cover{ height: 140px;overflow: hidden}.loglist-cover img {position:unset;    width: 730px;}}
+@media (max-width:415px) {.loglist-cover{ height: 160px;overflow: hidden}.loglist-cover img {position:unset;	width: 730px;}}
+@media (max-width:375px) {.loglist-cover{ height: 140px;overflow: hidden}.loglist-cover img {position:unset;	width: 730px;}}
 /* 条目的其他内容 */
 .loglist-content {
-    font-size: medium;
-    margin-left: 1px;
-    margin-bottom: 5px;
-    margin-right: 3px;
-    margin-top: 30px
+	font-size: medium;
+	margin-left: 1px;
+	margin-bottom: 5px;
+	margin-right: 3px;
+	margin-top: 30px
 }
 .log-info {
-    font-size: small;
-    letter-spacing: 0.5px;
-    color: #404040 !important
+	font-size: small;
+	letter-spacing: 0.5px;
+	color: #404040 !important
 }
 .log-info a {
-    color: #929292
+	color: #929292
 }
 .log-count {
-    font-size: small
+	font-size: small
 }
 .log-count a {
-    color: #252525
+	color: #252525
 }
 /* 侧边栏组件的一些样式 */
 .bloggerinfo {
-    margin-bottom: -10px;
-    text-align: center
+	margin-bottom: -10px;
+	text-align: center
 }
 .bloggerinfo-img {
-    width: 100px;
-    height: 100px;
-    border: 0px solid #c2a9a9;
-    border-radius: 50%
+	width: 100px;
+	height: 100px;
+	border: 0px solid #c2a9a9;
+	border-radius: 50%
 }
 .comm-lates-name {
-    font-weight: bolder
+	font-weight: bolder
 }
 .bloginfo-name {
-    font-size: x-large;
-    margin-top: 15px;
-    margin-bottom: 0px
+	font-size: x-large;
+	margin-top: 15px;
+	margin-bottom: 0px
 }
 .bloginfo-descript {
-    margin-top: 20px;
-    margin-bottom: 15px;
-    color: #929292
+	margin-top: 20px;
+	margin-bottom: 15px;
+	color: #929292
 }
 /* 搜索栏 */
 .search {
-    width: 80%;
-    box-shadow: none;
-    float: left;
-    font-size: 1rem;
-    padding: 0.4rem 0.75rem;
-    line-height: 1.5;
-    color: #495057;
-    border: 1px solid #ced4da;
-    /* 兼容 Safari ，Safari默认input会有1px的上下外边距 */
-    margin-block: 0;
-    border-radius: 0.25rem
+	width: 80%;
+	box-shadow: none;
+	float: left;
+	font-size: 1rem;
+	padding: 0.4rem 0.75rem;
+	line-height: 1.5;
+	color: #495057;
+	border: 1px solid #ced4da;
+	/* 兼容 Safari ，Safari默认input会有1px的上下外边距 */
+	margin-block: 0;
+	border-radius: 0.25rem
 }
 /* 文章阅读和文章条目的标签 */
 .tags {
-    border: 1px solid #e8e8e8;
-    padding: 1px 6px;
-    border-radius: 4px;
-    white-space: nowrap
+	border: 1px solid #e8e8e8;
+	padding: 1px 6px;
+	border-radius: 4px;
+	white-space: nowrap
 }
 /* 侧边栏组件中的标签 */
 .tag-container {
-    margin-block: 0;
-    text-overflow: ellipsis
+	margin-block: 0;
+	text-overflow: ellipsis
 }
 .tags-side {
-    padding: 2px 6px;
-    border-radius: 4px;
-    white-space: nowrap
+	padding: 2px 6px;
+	border-radius: 4px;
+	white-space: nowrap
 }
 /* 侧边栏组件中的最新文章样式 */
 .blog-lates,.blog-hot {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis
 }
 /* 返回上页图标 */
 .back-top {
-    font-size: 20px;
-    text-align: center;
-    height: 34px;
-    width: 34px;
-    margin-left: -90px;
-    position: absolute;
-    top: 151px;
-    border: 1px solid #dcdcdd;
-    color: #dcdcdd;
-    border-radius: 50%;
-    cursor: pointer
+	font-size: 20px;
+	text-align: center;
+	height: 34px;
+	width: 34px;
+	margin-left: -90px;
+	position: absolute;
+	top: 151px;
+	border: 1px solid #dcdcdd;
+	color: #dcdcdd;
+	border-radius: 50%;
+	cursor: pointer
 }
 .back-top:hover {
-    border: 1px solid #bbbbbb;
-    color: #bbbbbb
+	border: 1px solid #bbbbbb;
+	color: #bbbbbb
 }
 /* 文章条目中的分割线 */
 .list-line {
-    border: 0;
-    margin-top: 12px;
-    margin-bottom: -7px;
-    border-top: 2px solid rgb(245, 245, 246)
+	border: 0;
+	margin-top: 12px;
+	margin-bottom: -7px;
+	border-top: 2px solid rgb(245, 245, 246)
 }
 /* 侧边栏组件中的文章分类 */
 .log-classify-f {
-    letter-spacing: 1px;
-    font-size: 16px;
-    font-weight: 400
+	letter-spacing: 1px;
+	font-size: 16px;
+	font-weight: 400
 }
 .log-classify-c {
-    margin-left: -27px;
-    list-style: none;
-    font-size: medium
+	margin-left: -27px;
+	list-style: none;
+	font-size: medium
 }
 /* 侧边栏组件中的最新评论 */
 .logcom-latest-time {
-    position: absolute;
-    right: 10px;
-    color: #b5b5b5;
-    margin-left: 10px;
-    font-size: small
+	position: absolute;
+	right: 10px;
+	color: #b5b5b5;
+	margin-left: 10px;
+	font-size: small
 }
 .comment-info_img {
-    width: 27px;
-    margin-bottom: 4px;
-    margin-right: 3px;
-    border-radius: 50%;
-    vertical-align: middle;
-    border-style: none
+	width: 27px;
+	margin-bottom: 4px;
+	margin-right: 3px;
+	border-radius: 50%;
+	vertical-align: middle;
+	border-style: none
 }
 /* 各处的日期文字样式 */
 .date {
-    margin: 0;
-    text-align: center;
-    color: #7f7f7f
+	margin: 0;
+	text-align: center;
+	color: #7f7f7f
 }
 .date a {
-    color: #7f7f7f
+	color: #7f7f7f
 }
 .log-con .date {
-    font-size: small
+	font-size: small
 }
 .log-title {
-    text-align: center;
-    margin-bottom: 30px;
-    font-size: 1.75rem
+	text-align: center;
+	margin-bottom: 30px;
+	font-size: 1.75rem
 }
 .page-title {
-    margin-bottom: 30px;
-    font-size: 1.75rem
+	margin-bottom: 30px;
+	font-size: 1.75rem
 }
 /* 相邻文章按钮的样式 */
 .neighbor-log {
-    overflow: hidden;
-    margin-block: 20px
+	overflow: hidden;
+	margin-block: 20px
 }
 .prev-log {
-    margin: 3px 0px;
-    float: left;
-    padding: 6px 6px 4px 6px;
-    font-size: medium;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    border-radius: 50rem
+	margin: 3px 0px;
+	float: left;
+	padding: 6px 6px 4px 6px;
+	font-size: medium;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 50rem
 }
 .next-log {
-    margin: 3px 0px;
-    float: right;
-    padding: 6px 6px 4px 6px;
-    font-size: medium;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    border-radius: 50rem
+	margin: 3px 0px;
+	float: right;
+	padding: 6px 6px 4px 6px;
+	font-size: medium;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 50rem
 }
 .comment-info a {
-    color: #4c4c4c;
-    padding-left: 5px
+	color: #4c4c4c;
+	padding-left: 5px
 }
 .comment-info hr {
-    margin: 4px 0px
+	margin: 4px 0px
 }
 
 /* 网页足部
 ---------------------------------------------------*/
 .footinfo {
-    line-height: 2;
-    padding-block: 10px;
-    text-align: center !important;
+	line-height: 2;
+	padding-block: 10px;
+	text-align: center !important;
 }
 
 /* 图片放大
 ---------------------------------------------------*/
 img[data-action="zoom"] {
-    cursor: pointer;
-    cursor: -webkit-zoom-in;
-    cursor: -moz-zoom-in;
+	cursor: pointer;
+	cursor: -webkit-zoom-in;
+	cursor: -moz-zoom-in;
   }
 .zoom-img,
 .zoom-img-wrap {
-    position: relative;
-    z-index: 666;
-    -webkit-transition: all 300ms;
-         -o-transition: all 300ms;
-            transition: all 300ms;
+	position: relative;
+	z-index: 666;
+	-webkit-transition: all 300ms;
+		 -o-transition: all 300ms;
+			transition: all 300ms;
   }
 img.zoom-img {
-    cursor: pointer;
-    cursor: -webkit-zoom-out;
-    cursor: -moz-zoom-out;
+	cursor: pointer;
+	cursor: -webkit-zoom-out;
+	cursor: -moz-zoom-out;
   }
 .zoom-overlay {
-    z-index: 420;
-    background: #fff;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-    opacity: 0;
-    -webkit-transition:      opacity 300ms;
-         -o-transition:      opacity 300ms;
-            transition:      opacity 300ms;
+	z-index: 420;
+	background: #fff;
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	pointer-events: none;
+	opacity: 0;
+	-webkit-transition:	  opacity 300ms;
+		 -o-transition:	  opacity 300ms;
+			transition:	  opacity 300ms;
   }
 .zoom-overlay-open .zoom-overlay {
-    opacity: 1;
+	opacity: 1;
   }
 .zoom-overlay-open,
 .zoom-overlay-transitioning {
-    cursor: default;
+	cursor: default;
   }
 .cover-unclip {
-    /* 放大后的图片无裁剪、无圆角、无透明度 */
-    clip: unset!important;
-    border-radius: unset!important;
-    opacity: 1!important
+	/* 放大后的图片无裁剪、无圆角、无透明度 */
+	clip: unset!important;
+	border-radius: unset!important;
+	opacity: 1!important
 }
 /* toc
 ---------------------------------------------------*/
 .toc-con {
-    padding: 30px;
-    padding-right: 50px;
-    left: 150px;
-    width: 300px;
-    position: absolute;
-    top: 200px
+	padding: 30px;
+	padding-right: 50px;
+	left: 150px;
+	width: 300px;
+	position: absolute;
+	top: 200px
 }
 .toc-con li{
-    font-size: 14px;
-    line-height: 1.8rem;
-    cursor: pointer;
-    list-style: none;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap
+	font-size: 14px;
+	line-height: 1.8rem;
+	cursor: pointer;
+	list-style: none;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap
 }
 .toc-con div {
-    scrollbar-color: #0000002b #fff0
+	scrollbar-color: #0000002b #fff0
 }
 .toc-con div::-webkit-scrollbar {
-    width: 5px;
-    background-color: rgb(0 0 0 / 0%)
+	width: 5px;
+	background-color: rgb(0 0 0 / 0%)
 }
 .toc-con div::-webkit-scrollbar-thumb {
-    background-color: rgb(0 0 0 / 10%)
+	background-color: rgb(0 0 0 / 10%)
 }
 /* page 页面 */
 #page{
-    margin-bottom: 24px
+	margin-bottom: 24px
 }
 
 /* 摘要的溢出（overflow）操作 
 ---------------------------------------------------*/
 .subtitle-overflow {
-    max-width: 700px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis
+	max-width: 700px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis
 }
 
 /* 「归档」的样式 
 ---------------------------------------------------*/
 .archive {
-    font-size: 16px;
-    padding: 4px;
-    border-color: #ced4da
+	font-size: 16px;
+	padding: 4px;
+	border-color: #ced4da
 }
 
 /* 一些适应各屏幕尺寸显示效果的样式
@@ -1223,244 +1223,244 @@ img.zoom-img {
 @media all and (max-width: 1200px) and (min-width: 992px) {
 
 	/* 方便在中、小屏幕隐藏元素的class */
-    .mh {
-        display: none
-    }
-    .bloggerinfo-img {
-        width: 70px;
-        height: 70px
-    }
-    .bloginfo-name {
-        margin-top: 32px
-    }
-    /* 中型屏状态下的日历 */
-    #calendar {
-        margin-left: -8px;
-    }
+	.mh {
+		display: none
+	}
+	.bloggerinfo-img {
+		width: 70px;
+		height: 70px
+	}
+	.bloginfo-name {
+		margin-top: 32px
+	}
+	/* 中型屏状态下的日历 */
+	#calendar {
+		margin-left: -8px;
+	}
 }
 
 @media all and (max-width: 991px) {
-    /* 头部无容器的限宽 */
-    .blog-header-c {
-        max-width: unset !important
-    } 
-    .blog-header-c {
-        height: 74px
-    }
-    body {
-        width: 100%;
-        margin: -2px;
-        padding-left: 2px
-    }
+	/* 头部无容器的限宽 */
+	.blog-header-c {
+		max-width: unset !important
+	} 
+	.blog-header-c {
+		height: 74px
+	}
+	body {
+		width: 100%;
+		margin: -2px;
+		padding-left: 2px
+	}
 	/* 方便在中、小屏幕隐藏元素的 class */
-    .mh {
-        display: none
-    }
-    .loglist-title {
-        font-size: 18px;
-        font-weight: 500
-    }
-    .bloggerinfo {
-        margin-bottom: 0px
-    }
-    .mb-5, .mtop-5 {
-        margin-bottom: 2rem !important
-    }
-    .log-title {
-        text-align: left
-    }
-    .log-con {
-        padding: 30px 16px
-    }
-    .commentform .comment-info {
-        width: 100%
-    }
+	.mh {
+		display: none
+	}
+	.loglist-title {
+		font-size: 18px;
+		font-weight: 500
+	}
+	.bloggerinfo {
+		margin-bottom: 0px
+	}
+	.mb-5, .mtop-5 {
+		margin-bottom: 2rem !important
+	}
+	.log-title {
+		text-align: left
+	}
+	.log-con {
+		padding: 30px 16px
+	}
+	.commentform .comment-info {
+		width: 100%
+	}
 
-    /* 展开菜单后，博客头部的下边距变大 */
-    .bottom-change {
-        margin-bottom: 13px
-    }
+	/* 展开菜单后，博客头部的下边距变大 */
+	.bottom-change {
+		margin-bottom: 13px
+	}
 
-    /* 为文章列出页卡片在小屏幕的观感体验优化 */
-    .card-title {
-        margin-bottom: 10px
-    }
-    .loglist-content {
-        margin-top: 10px
-    }
-    .loglist-tag {
-        margin-top: 10px
-    }
-    /* 博客头部的下边距 */
-    .blog-header {
-        margin-bottom: 1.6rem
-    }
-    /* 评论的信息栏变化 */
-    .comment-post input {
-        padding: 0.5em 0.75em
-    }
-    /* 侧边栏日历 */
-    #calendar {
-        margin-left: 0
-    }
+	/* 为文章列出页卡片在小屏幕的观感体验优化 */
+	.card-title {
+		margin-bottom: 10px
+	}
+	.loglist-content {
+		margin-top: 10px
+	}
+	.loglist-tag {
+		margin-top: 10px
+	}
+	/* 博客头部的下边距 */
+	.blog-header {
+		margin-bottom: 1.6rem
+	}
+	/* 评论的信息栏变化 */
+	.comment-post input {
+		padding: 0.5em 0.75em
+	}
+	/* 侧边栏日历 */
+	#calendar {
+		margin-left: 0
+	}
 }
 /* 在平板一些处于中间尺寸的不常见设备所做的缩放和其他一些调整样式 */
 @media all and (max-width: 991px) and (min-width: 768px) {
 
-    #calendar {
-        transform: scale(0.8);
-        margin-left: -14px;
-        margin-top: -14px
-    }
-    .unstyle-li form {
-        transform: scale(0.7);
-        width: 255px;
-        margin-left: -47px
-    }
-    /* 中屏幕下缩短边栏评论日期显示 */
-    .logcom-latest-time {
-        max-width: 60px
-    }
+	#calendar {
+		transform: scale(0.8);
+		margin-left: -14px;
+		margin-top: -14px
+	}
+	.unstyle-li form {
+		transform: scale(0.7);
+		width: 255px;
+		margin-left: -47px
+	}
+	/* 中屏幕下缩短边栏评论日期显示 */
+	.logcom-latest-time {
+		max-width: 60px
+	}
 
 }
 /* 对一些极小尺寸屏幕所做的比较妥协的缩放等调整 */
 @media all and (max-width: 349px) {
 
-    #calendar {
-        transform: scale(0.7);
-        margin-left: -46px;
-        margin-top: -14px
-    }
-    .unstyle-li form {
-        transform: scale(0.7);
-        width: 255px;
-        margin-left: -47px
-    }
-    .bloginfo-name {
-        font-size: small
-    }
+	#calendar {
+		transform: scale(0.7);
+		margin-left: -46px;
+		margin-top: -14px
+	}
+	.unstyle-li form {
+		transform: scale(0.7);
+		width: 255px;
+		margin-left: -47px
+	}
+	.bloginfo-name {
+		font-size: small
+	}
 }
 /* 普通移动设备的显示样式 */
 @media all and (max-width: 577px) {
-    .dropdown-menus .list-menu{
-        padding-bottom : 0px
-    }
-    .nav-link {
-        padding: 8px;
-    }
-    /* 卡片容器内边距略小一点 */
-    .card-padding {
-        padding: 14px;
-    }
-    .side-bar .widget {
-        margin-bottom: 1.5rem
-    }
-    .pagination:after {
-        content: "";
-        margin-bottom: 20px;
-        display: block;
-        clear: both
-    }
-    .bar_top_line {
-        display: block;
-        margin-bottom: 23px
-    }
-    .pagination span {
-        padding: 5.5px 9px 3px 9px
-    }
-    .pagination a {
-        padding: 5.5px 9px 3px 9px
-    }
-    .comment .comment-info {
-        float: left;
-        margin-left: unset;
-        width: 100%
-    }
-    .com_control {
-        height: 44px
-    }
-    .mb-5, .mtop-5 {
-        margin-bottom: 1.6rem !important
-    }
-    #pagenavi {
-        line-height: 45px
-    }
-    .loglist-content p {
-        font-size: 14px;
-    }
+	.dropdown-menus .list-menu{
+		padding-bottom : 0px
+	}
+	.nav-link {
+		padding: 8px;
+	}
+	/* 卡片容器内边距略小一点 */
+	.card-padding {
+		padding: 14px;
+	}
+	.side-bar .widget {
+		margin-bottom: 1.5rem
+	}
+	.pagination:after {
+		content: "";
+		margin-bottom: 20px;
+		display: block;
+		clear: both
+	}
+	.bar_top_line {
+		display: block;
+		margin-bottom: 23px
+	}
+	.pagination span {
+		padding: 5.5px 9px 3px 9px
+	}
+	.pagination a {
+		padding: 5.5px 9px 3px 9px
+	}
+	.comment .comment-info {
+		float: left;
+		margin-left: unset;
+		width: 100%
+	}
+	.com_control {
+		height: 44px
+	}
+	.mb-5, .mtop-5 {
+		margin-bottom: 1.6rem !important
+	}
+	#pagenavi {
+		line-height: 45px
+	}
+	.loglist-content p {
+		font-size: 14px;
+	}
 	/* 评论相关 */
-    .comment-post #comment {
-        border-radius: 6px;
-    }
-    .comment-post input {
-        width: 100%
-    }
-    .commentform .comment-info {
-        margin-top: -5px
-    }
-    #comment-place {
-        margin-bottom: 80px
-    }
-    .com_control {
-        border: 1px solid #ced4da;
-        border-radius: 6px !important;
-        margin-top: 10px
-    }
-    .comment-mail {
-        margin-bottom: 10px;
-    }
-    .comment .comment-post {
-        display: table
-    }
-    /* 评论列表换新样式 */
-    .arrow {
-        display: none
-    }
-    .comment .comment-infos {
-        margin-left: 0;
-        font-size: 14px
-    }
-    .comment .avatar {
-        margin: 6px 8px;
-        height: 30px;
-        width: 30px;
-    }
-    /* 摘要的溢出（overflow）操作 在 小屏幕上要截得多一点 */
-    .subtitle-overflow {
-        max-width: 80%
-    }
-    /* 网页顶部的下拉菜单在移动端的显示优化 */
-    .dropdown-menus .list-menu{
-        padding: 0px;
-        letter-spacing: 2px
-    }
+	.comment-post #comment {
+		border-radius: 6px;
+	}
+	.comment-post input {
+		width: 100%
+	}
+	.commentform .comment-info {
+		margin-top: -5px
+	}
+	#comment-place {
+		margin-bottom: 80px
+	}
+	.com_control {
+		border: 1px solid #ced4da;
+		border-radius: 6px !important;
+		margin-top: 10px
+	}
+	.comment-mail {
+		margin-bottom: 10px;
+	}
+	.comment .comment-post {
+		display: table
+	}
+	/* 评论列表换新样式 */
+	.arrow {
+		display: none
+	}
+	.comment .comment-infos {
+		margin-left: 0;
+		font-size: 14px
+	}
+	.comment .avatar {
+		margin: 6px 8px;
+		height: 30px;
+		width: 30px;
+	}
+	/* 摘要的溢出（overflow）操作 在 小屏幕上要截得多一点 */
+	.subtitle-overflow {
+		max-width: 80%
+	}
+	/* 网页顶部的下拉菜单在移动端的显示优化 */
+	.dropdown-menus .list-menu{
+		padding: 0px;
+		letter-spacing: 2px
+	}
 }
 /* 为 toc 移动端设立的样式 */
 @media all and (max-width: 1274px) {
-    .toc-con {
-        height: 100vh;
-        width: 60%;
-        max-width: 300px;
-        padding-right: 30px;
-        /* 磨砂效果 */
-        background: rgba(237, 237, 237, 0.8);
-        backdrop-filter: blur(2px);
-        /* 始终固定位置 */
-        z-index: 2;
-        position: fixed!important;
-        top: 0!important
-    }
-    .toc-link {
-        color: rgb(189, 189, 189);
-        font-size: 10px;
-        padding-left: 10px;
-    }
-    /* toc 在 iPhone 等苹果设备上的磨砂效果  */
-    @supports ((-webkit-backdrop-filter: saturate(180%) blur(20px)) or(backdrop-filter: saturate(180%) blur(20px))) {
-        .toc-con {
-            background: rgba(237, 237, 237, 0.8);
-            -webkit-backdrop-filter: saturate(180%) blur(2px);
-            backdrop-filter: blur(2px);
-        }
-    }
+	.toc-con {
+		height: 100vh;
+		width: 60%;
+		max-width: 300px;
+		padding-right: 30px;
+		/* 磨砂效果 */
+		background: rgba(237, 237, 237, 0.8);
+		backdrop-filter: blur(2px);
+		/* 始终固定位置 */
+		z-index: 2;
+		position: fixed!important;
+		top: 0!important
+	}
+	.toc-link {
+		color: rgb(189, 189, 189);
+		font-size: 10px;
+		padding-left: 10px;
+	}
+	/* toc 在 iPhone 等苹果设备上的磨砂效果  */
+	@supports ((-webkit-backdrop-filter: saturate(180%) blur(20px)) or(backdrop-filter: saturate(180%) blur(20px))) {
+		.toc-con {
+			background: rgba(237, 237, 237, 0.8);
+			-webkit-backdrop-filter: saturate(180%) blur(2px);
+			backdrop-filter: blur(2px);
+		}
+	}
 }

--- a/content/templates/default/echo_log.php
+++ b/content/templates/default/echo_log.php
@@ -8,28 +8,28 @@ if (!defined('EMLOG_ROOT')) {
 ?>
 
 <article class="container log-con blog-container">
-    <span class="back-top mh" onclick="history.go(-1);">&laquo;</span>
-    <h1 class="log-title"><?php topflg($top) ?><?= $log_title ?></h1>
-    <p class="date">
-        <b>时间：</b><?= date('Y-n-j', $date) ?>&nbsp;&nbsp;&nbsp;&nbsp;
-        <b>作者：</b><?php blog_author($author) ?>&nbsp;&nbsp;&nbsp;&nbsp;
-        <b>分类：</b><?php blog_sort($logid) ?>
+	<span class="back-top mh" onclick="history.go(-1);">&laquo;</span>
+	<h1 class="log-title"><?php topflg($top) ?><?= $log_title ?></h1>
+	<p class="date">
+		<b>时间：</b><?= date('Y-n-j', $date) ?>&nbsp;&nbsp;&nbsp;&nbsp;
+		<b>作者：</b><?php blog_author($author) ?>&nbsp;&nbsp;&nbsp;&nbsp;
+		<b>分类：</b><?php blog_sort($logid) ?>
 
 		<?php editflg($logid, $author) ?>
 
-    </p>
-    <hr class="bottom-5"/>
-    <div class="markdown" id="emlogEchoLog"><?= $log_content ?></div>
-    <p class="top-5"><?php blog_tag($logid) ?></p>
+	</p>
+	<hr class="bottom-5"/>
+	<div class="markdown" id="emlogEchoLog"><?= $log_content ?></div>
+	<p class="top-5"><?php blog_tag($logid) ?></p>
 
 	<?php doAction('log_related', $logData) ?>
 
-    <nav class="neighbor-log"><?php neighbor_log($neighborLog) ?></nav>
+	<nav class="neighbor-log"><?php neighbor_log($neighborLog) ?></nav>
 
 	<?php blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allow_remark) ?>
 	<?php blog_comments($comments) ?>
 
-    <div style="clear:both;"></div>
+	<div style="clear:both;"></div>
 </article>
 
 <?php include View::getView('footer') ?>

--- a/content/templates/default/footer.php
+++ b/content/templates/default/footer.php
@@ -6,18 +6,18 @@ if (!defined('EMLOG_ROOT')) {
 	exit('error!');
 }
 ?>
-    <footer>
-        <div class="container footinfo blog-footer">
-                <?php
-                    if(!empty($icp)){
-                        echo '<div><a href="https://beian.miit.gov.cn/" target="_blank">'.$icp.'</a></div>';
-                    }
-                ?>
-                <?= $footer_info ?>
-                <?php doAction('index_footer') ?>
-        </div>
-    </footer>
-    <script src="<?= TEMPLATE_URL ?>js/common_tpl.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
-    <script src="<?= TEMPLATE_URL ?>js/zoom.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
+	<footer class="blog-footer">
+		<div class="container footinfo">
+				<?php
+					if(!empty($icp)){
+						echo '<div><a href="https://beian.miit.gov.cn/" target="_blank">'.$icp.'</a></div>';
+					}
+				?>
+				<?= $footer_info ?>
+				<?php doAction('index_footer') ?>
+		</div>
+	</footer>
+	<script src="<?= TEMPLATE_URL ?>js/common_tpl.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
+	<script src="<?= TEMPLATE_URL ?>js/zoom.js?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
 </body>
 </html>

--- a/content/templates/default/header.php
+++ b/content/templates/default/header.php
@@ -14,39 +14,38 @@ require_once View::getView('module');
 <!doctype html>
 <html lang="zh-cn">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title><?= $site_title ?></title>
-    <meta name="keywords" content="<?= $site_key ?>"/>
-    <meta name="description" content="<?= $site_description ?>"/>
-    <base href="<?= BLOG_URL ?>"/>
-    <link rel="shortcut icon" href="<?= BLOG_URL ?>favicon.ico"/>
-    <link rel="alternate" title="RSS" href="<?= BLOG_URL ?>rss.php" type="application/rss+xml"/>
-    <link href="<?= TEMPLATE_URL ?>css/style.css?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>" rel="stylesheet" type="text/css"/>
-    <link href="<?= TEMPLATE_URL ?>css/markdown.css?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>" rel="stylesheet" type="text/css"/>
-    <script src="<?= TEMPLATE_URL ?>js/jquery.min.3.5.1.js?v=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
-    <script>function sendinfo(url) {  // 日历生成和翻页
-            $("#calendar").load(url)
-        }</script>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<title><?= $site_title ?></title>
+	<meta name="keywords" content="<?= $site_key ?>"/>
+	<meta name="description" content="<?= $site_description ?>"/>
+	<base href="<?= BLOG_URL ?>"/>
+	<link rel="shortcut icon" href="<?= BLOG_URL ?>favicon.ico"/>
+	<link rel="alternate" title="RSS" href="<?= BLOG_URL ?>rss.php" type="application/rss+xml"/>
+	<link href="<?= TEMPLATE_URL ?>css/style.css?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>" rel="stylesheet" type="text/css"/>
+	<link href="<?= TEMPLATE_URL ?>css/markdown.css?t=<?= Option::EMLOG_VERSION_TIMESTAMP ?>" rel="stylesheet" type="text/css"/>
+	<script src="<?= TEMPLATE_URL ?>js/jquery.min.3.5.1.js?v=<?= Option::EMLOG_VERSION_TIMESTAMP ?>"></script>
+	<script>function sendinfo(url) {  // 日历生成和翻页
+			$("#calendar").load(url)
+		}</script>
 	<?php doAction('index_head') ?>
 </head>
 
 <body>
 <nav class="blog-header">
-    <div class="blog-header-c container">
-        <a class="blog-header-title" href="<?= BLOG_URL ?>"><?= $blogname ?></a>
-        <div class="blog-header-subtitle subtitle-overflow" title="<?= $bloginfo ?>"><?= $bloginfo ?></div>
-        <div class="blog-header-toggle">
-            <svg class="blogtoggle-icon">
-                <rect x="1" y="1" fill="#5F5F5F" width="26" height="1.6"/>
-                <rect x="1" y="8" fill="#5F5F5F" width="26" height="1.6"/>
-                <rect x="1" y="15" fill="#5F5F5F" width="26" height="1.6"/>
-            </svg>
-        </div>
+	<div class="blog-header-c container">
+		<a class="blog-header-title" href="<?= BLOG_URL ?>"><?= $blogname ?></a>
+		<div class="blog-header-subtitle subtitle-overflow" title="<?= $bloginfo ?>"><?= $bloginfo ?></div>
+		<div class="blog-header-toggle">
+			<svg class="blogtoggle-icon">
+				<rect x="1" y="1" fill="#5F5F5F" width="26" height="1.6"/>
+				<rect x="1" y="8" fill="#5F5F5F" width="26" height="1.6"/>
+				<rect x="1" y="15" fill="#5F5F5F" width="26" height="1.6"/>
+			</svg>
+		</div>
 
 		<?php blog_navi() ?>
 		<?php doAction('index_navi_ext') ?>
 
-    </div>
+	</div>
 </nav>
-

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -4,373 +4,373 @@
  * jqurey添加动画扩展。先加速度至配速的50%，再减速到零
  */
 jQuery.extend(jQuery.easing, {
-    easeInOut: function (x, t, b, c, d) {
-        if ((t /= d / 2) < 1) return c / 2 * t * t + b
-        return -c / 2 * ((--t) * (t - 2) - 1) + b
-    }
+	easeInOut: function (x, t, b, c, d) {
+		if ((t /= d / 2) < 1) return c / 2 * t * t + b
+		return -c / 2 * ((--t) * (t - 2) - 1) + b
+	}
 })
 
 var myBlog = {
-    /**
-     * 初始化
-     */
-    init: function () {
-        this.tocAnalyse()  // toc目录生成
-        if ($("#comment-info").length == 0) {  // 大屏幕登录状态，评论框下两角变圆角
-            $(".commentform #comment").css("height", "140px")
-                .css('border-radius', '10px')
-        }
-        for (let num = 0; num < $(".markdown img").length; num++) {  // 为正文中的图片添加查看大图（默认认为图片父标签<a>中的链接是图片原地址）
-            let $this = $(".markdown img:eq(" + num + ")")
-            let sourceSrc = $(".markdown img:eq(" + num + ")").parent().attr('href')
+	/**
+	* 初始化
+	*/
+	init: function () {
+		this.tocAnalyse()  // toc目录生成
+		if ($("#comment-info").length == 0) {  // 大屏幕登录状态，评论框下两角变圆角
+			$(".commentform #comment").css("height", "140px")
+				.css('border-radius', '10px')
+		}
+		for (let num = 0; num < $(".markdown img").length; num++) {  // 为正文中的图片添加查看大图（默认认为图片父标签<a>中的链接是图片原地址）
+			let $this = $(".markdown img:eq(" + num + ")")
+			let sourceSrc = $(".markdown img:eq(" + num + ")").parent().attr('href')
 
-            if (typeof sourceSrc == "undefined" || sourceSrc.match(/\.(jpeg|jpg|gif|png)$/i) == null) {
-                continue
-            }
+			if (typeof sourceSrc == "undefined" || sourceSrc.match(/\.(jpeg|jpg|gif|png)$/i) == null) {
+				continue
+			}
 
-            $this.attr("data-action", "zoom")
-                .parent().attr("sourcesrc", sourceSrc)
-                .removeAttr("href")
-        }
-        $("#commentform").attr("onsubmit", "return myBlog.comSubmitTip()")  // 评论提交在表单验证未通过的情况下是不能提交的
-    }, /**
-     * 回复
-     */
-    comReply: function ($t) {
-        var $ele, getpid, $com_board
-        $ele = $t.parent().parent()
-        getpid = $ele.parent().attr("id").substring(8)
-        $com_board = $("#comment-post")
+			$this.attr("data-action", "zoom")
+				.parent().attr("sourcesrc", sourceSrc)
+				.removeAttr("href")
+		}
+		$("#commentform").attr("onsubmit", "return myBlog.comSubmitTip()")  // 评论提交在表单验证未通过的情况下是不能提交的
+	}, /**
+	* 回复
+	*/
+	comReply: function ($t) {
+		var $ele, getpid, $com_board
+		$ele = $t.parent().parent()
+		getpid = $ele.parent().attr("id").substring(8)
+		$com_board = $("#comment-post")
 
-        $ele.append($com_board)
-        $("#comment-pid").attr("value", getpid)
-        $("#cancel-reply").css("display", "unset")
-        $("#comment-place").toggleClass("com-bottom")
-    }, /**
-     * 取消回复
-     */
-    cancelReply: function ($t) {
-        $("#comment-pid").attr("value", "0")
-        $("#cancel-reply").css("display", "none")
-        $("#comment-place").append($("#comment-post"))
-            .toggleClass("com-bottom")
-    }, /**
-     * 手机点击展开导航按钮
-     */
-    navToggle: function ($t) {
-        var time, effect, $navbar, $nav_c, nav_height
-        time = 'fast'
-        effect = 'easeInOut'
-        $navbar = $("#navbarResponsive")
-        $nav_c = $(".blog-header-c")
-        nav_height = ($nav_c.height() == 74) ? $navbar.height() + 74 : 74
+		$ele.append($com_board)
+		$("#comment-pid").attr("value", getpid)
+		$("#cancel-reply").css("display", "unset")
+		$("#comment-place").toggleClass("com-bottom")
+	}, /**
+	* 取消回复
+	*/
+	cancelReply: function ($t) {
+		$("#comment-pid").attr("value", "0")
+		$("#cancel-reply").css("display", "none")
+		$("#comment-place").append($("#comment-post"))
+			.toggleClass("com-bottom")
+	}, /**
+	* 手机点击展开导航按钮
+	*/
+	navToggle: function ($t) {
+		var time, effect, $navbar, $nav_c, nav_height
+		time = 'fast'
+		effect = 'easeInOut'
+		$navbar = $("#navbarResponsive")
+		$nav_c = $(".blog-header-c")
+		nav_height = ($nav_c.height() == 74) ? $navbar.height() + 74 : 74
 
-        $nav_c.animate({height: nav_height + 'px'}, time, effect)
-        $navbar.slideToggle(time, effect)
-    }, /**
-     * 定位大屏状态下的导航下拉框位置
-     */
-    calMargin: function ($t) {
-        if (window.outerWidth < 992) return
-        var $childMenu, menuWidth, count
+		$nav_c.animate({height: nav_height + 'px'}, time, effect)
+		$navbar.slideToggle(time, effect)
+	}, /**
+	* 定位大屏状态下的导航下拉框位置
+	*/
+	calMargin: function ($t) {
+		if (window.outerWidth < 992) return
+		var $childMenu, menuWidth, count
 
-        menuWidth = 135  // 大屏幕端的子导航下拉框宽度(px)，可根据需要修改
-        count = ($t.outerWidth() - menuWidth) / 2 + "px"
-        $childMenu = $t.siblings('.dropdown-menus')
+		menuWidth = 135  // 大屏幕端的子导航下拉框宽度(px)，可根据需要修改
+		count = ($t.outerWidth() - menuWidth) / 2 + "px"
+		$childMenu = $t.siblings('.dropdown-menus')
 
-        $childMenu.css("width", menuWidth + "px")
-            .css("margin-left", count)
-    }, /**
-     * 提交评论前对表单的验证
-     */
-    comTip: '', comSubmitTip: function (value) {
-        if (value == 'judge') {
-            let cnReg = /[\u4e00-\u9fa5]/
-            let mailReg = /^[a-z0-9]+([._\\-]*[a-z0-9])*@([a-z0-9]+[-a-z0-9]*[a-z0-9]+.){1,63}[a-z0-9]+$/
-            let urlReg = /[^\s]*\.+[^\s]/
+		$childMenu.css("width", menuWidth + "px")
+			.css("margin-left", count)
+	}, /**
+	* 提交评论前对表单的验证
+	*/
+	comTip: '', comSubmitTip: function (value) {
+		if (value == 'judge') {
+			let cnReg = /[\u4e00-\u9fa5]/
+			let mailReg = /^[a-z0-9]+([._\\-]*[a-z0-9])*@([a-z0-9]+[-a-z0-9]*[a-z0-9]+.){1,63}[a-z0-9]+$/
+			let urlReg = /[^\s]*\.+[^\s]/
 
-            let isCn = $('#commentform').attr('is-chinese')
-            let comContent = $('#comment').val()
-            let mail = $('#info_m').val()
-            let url = $('#info_u').val()
+			let isCn = $('#commentform').attr('is-chinese')
+			let comContent = $('#comment').val()
+			let mail = $('#info_m').val()
+			let url = $('#info_u').val()
 
-            if (isCn == 'y' && !cnReg.test(comContent)) {
-                this.comTip = "评论内容需要包含中文！"
-            } else if (typeof mail !== "undefined" && mail != '' && !mailReg.test(mail)) {
-                this.comTip = "邮箱格式错误！"
-            } else if (typeof url !== "undefined" && url != '' && !urlReg.test(url)) {
-                this.comTip = "网址格式错误！"
-            } else {
-                this.comTip = ''
-            }
-        } else {
-            if (this.comTip != '') {
-                alert(this.comTip)
-                return false
-            } else {
-                return true
-            }
-        }
-    }, /**
-     * 显示(隐藏)验证码模态窗
-     */
-    viewModal: function () {
-        var $modal, $lock
-        $modal = $(".modal-dialog,.lock-screen")
-        $lock = $(".lock-screen")
+			if (isCn == 'y' && !cnReg.test(comContent)) {
+				this.comTip = "评论内容需要包含中文！"
+			} else if (typeof mail !== "undefined" && mail != '' && !mailReg.test(mail)) {
+				this.comTip = "邮箱格式错误！"
+			} else if (typeof url !== "undefined" && url != '' && !urlReg.test(url)) {
+				this.comTip = "网址格式错误！"
+			} else {
+				this.comTip = ''
+			}
+		} else {
+			if (this.comTip != '') {
+				alert(this.comTip)
+				return false
+			} else {
+				return true
+			}
+		}
+	}, /**
+	* 显示(隐藏)验证码模态窗
+	*/
+	viewModal: function () {
+		var $modal, $lock
+		$modal = $(".modal-dialog,.lock-screen")
+		$lock = $(".lock-screen")
 
-        $('body,html').toggleClass('scroll-fix')
-        $modal.fadeToggle()
-        $("input[name='imgcode']").attr("autocomplete", "off")
-    }, /**
-     * 点击刷新验证码
-     */
-    captchaRefresh: function ($t) {
-        var timestamp = new Date().getTime()
-        var blogUrl = $("base").attr("href")
+		$('body,html').toggleClass('scroll-fix')
+		$modal.fadeToggle()
+		$("input[name='imgcode']").attr("autocomplete", "off")
+	}, /**
+	* 点击刷新验证码
+	*/
+	captchaRefresh: function ($t) {
+		var timestamp = new Date().getTime()
+		var blogUrl = $("base").attr("href")
 
-        $t.attr("src", blogUrl + "/include/lib/checkcode.php?" + timestamp)
-    }, /**
-     * 图片在点击时，将略缩图转化为原图
-     */
-    toggleImgSrc: function ($t) {
-        $t.addClass('zoomFocus')
-        $t.attr('src2', $t.attr('src'))
-        $t.attr('src', $t.parent().attr('sourcesrc'))
-    }, /**
-     * 归档下拉框的值被改变，跳转到相应日期文章的链接
-     */
-    jumpLink: function ($t) {
-        $(window).attr("location",$t.val())
-    },/**
-    * toc 效果
-    *
-    * 启用 toc 目录方式: 在文章最开头写上'[toc]'或者'<!--[toc]-->',最好是单独一行
-    */
-   tocFlag: /\[toc\]/gi,  // 判断toc是否声明的正则表达式
-   tocArray: new Array(),  // 储存toc的数组
-   tocSetArray: function(){  // 设置toc的数组内填数据
-       var $titles = $("#emlogEchoLog h1,h2,h3,h4,h5,h6:eq(0)")
+		$t.attr("src", blogUrl + "/include/lib/checkcode.php?" + timestamp)
+	}, /**
+	* 图片在点击时，将略缩图转化为原图
+	*/
+	toggleImgSrc: function ($t) {
+		$t.addClass('zoomFocus')
+		$t.attr('src2', $t.attr('src'))
+		$t.attr('src', $t.parent().attr('sourcesrc'))
+	}, /**
+	* 归档下拉框的值被改变，跳转到相应日期文章的链接
+	*/
+	jumpLink: function ($t) {
+		$(window).attr("location",$t.val())
+	},/**
+	* toc 效果
+	*
+	* 启用 toc 目录方式: 在文章最开头写上'[toc]'或者'<!--[toc]-->',最好是单独一行
+	*/
+	tocFlag: /\[toc\]/gi,  // 判断toc是否声明的正则表达式
+	tocArray: new Array(),  // 储存toc的数组
+	tocSetArray: function(){  // 设置toc的数组内填数据
+		var $titles = $("#emlogEchoLog h1,h2,h3,h4,h5,h6:eq(0)")
 
-       for (var i = 0; i < $titles.length; i++) {  // 将标签数据依次存入数组
-           let $tit = $("#emlogEchoLog [toc-date='title']:eq(" + i + ")")
-           myBlog.tocArray[i] = new Array()
+		for (var i = 0; i < $titles.length; i++) {  // 将标签数据依次存入数组
+			let $tit = $("#emlogEchoLog [toc-date='title']:eq(" + i + ")")
+			myBlog.tocArray[i] = new Array()
 
-           myBlog.tocArray[i]['type'] = $tit.prop('tagName').substring(1)
-           myBlog.tocArray[i]['content'] = $tit.text()
-           myBlog.tocArray[i]['pos'] = $tit.offset().top
-           myBlog.tocArray[i]['id'] = $tit.text()
-           $tit.attr("id", myBlog.tocArray[i]['id'])
-       }
-   }, /**
-    * toc 分析（toc 效果程序的入口）
-    */
-   tocAnalyse: function () {
-       var tocFlag = document.querySelector("#emlogEchoLog p")
+			myBlog.tocArray[i]['type'] = $tit.prop('tagName').substring(1)
+			myBlog.tocArray[i]['content'] = $tit.text()
+			myBlog.tocArray[i]['pos'] = $tit.offset().top
+			myBlog.tocArray[i]['id'] = $tit.text()
+			$tit.attr("id", myBlog.tocArray[i]['id'])
+		}
+	}, /**
+	* toc 分析（toc 效果程序的入口）
+	*/
+	tocAnalyse: function () {
+		var tocFlag = document.querySelector("#emlogEchoLog p")
 
-       if ($("#emlogEchoLog").length == 0) return  // 不在阅读页面  退出
-       if (!this.tocFlag.test($('#emlogEchoLog').html().substring(0, 30))) return  // 未声明 toc 标签，退出
-       tocFlag.innerHTML = tocFlag.innerHTML.replace(this.tocFlag, "")  // 去除 toc 声明
+		if ($("#emlogEchoLog").length == 0) return  // 不在阅读页面  退出
+		if (!this.tocFlag.test($('#emlogEchoLog').html().substring(0, 30))) return  // 未声明 toc 标签，退出
+		tocFlag.innerHTML = tocFlag.innerHTML.replace(this.tocFlag, "")  // 去除 toc 声明
 
-       var $logCon = $(".log-con")
-       var logConMar = parseInt($logCon.css("margin-left"))
-       var $titles = $("#emlogEchoLog h1,h2,h3,h4,h5,h6:eq(0)")
+		var $logCon = $(".log-con")
+		var logConMar = parseInt($logCon.css("margin-left"))
+		var $titles = $("#emlogEchoLog h1,h2,h3,h4,h5,h6:eq(0)")
 
-       if ($titles.length > 0) {
-           if (window.outerWidth > 1275){
-               $logCon.css("margin-left", logConMar + 150 + 'px')  // 文章正文向右偏移 150px
-           }
-       } else {
-           return  // 未发现标题（h标签） 退出
-       }
+		if ($titles.length > 0) {
+			if (window.outerWidth > 1275){
+				$logCon.css("margin-left", logConMar + 150 + 'px')  // 文章正文向右偏移 150px
+			}
+		} else {
+			return  // 未发现标题（h标签） 退出
+		}
 
-       $titles.attr("toc-date", "title")
-       this.tocSetArray()
-       this.tocRender()
-       this.tocMobileSet()
-   },/**
-    * toc 目录渲染
-    */
-   tocRender: function() {
-       var tocHtml = ''
-       var data = this.tocArray
-       var $logcon = $(".log-con")
-       var padNum = (window.outerWidth < 1276) ? 0 : parseInt($logcon.css("margin-left")) - 270
-       var judgeN = 0
-       var chilPad = 4
-       var minType = 6
+		$titles.attr("toc-date", "title")
+		this.tocSetArray()
+		this.tocRender()
+		this.tocMobileSet()
+	},/**
+	* toc 目录渲染
+	*/
+	tocRender: function() {
+		var tocHtml = ''
+		var data = this.tocArray
+		var $logcon = $(".log-con")
+		var padNum = (window.outerWidth < 1276) ? 0 : parseInt($logcon.css("margin-left")) - 270
+		var judgeN = 0
+		var chilPad = 4
+		var minType = 6
 
-       for (var i = 0; i < data.length; i++) {
-           if (data[i]['type'] < minType) minType = data[i]['type']
-       }
-       tocHtml = tocHtml + '<div class="toc-con" style="left:' + padNum + 'px" id="toc-con">'   // 渲染
-       tocHtml = tocHtml + '<div style="height:calc(100vh - 70px);overflow-y:scroll;" ><lu>'
-       for (var i = 0; i < data.length; i++) {
-           let k = minType
-           let itemType = data[i]['type']
-           let isPadding = ''
-           let isBold = ['', '']
+		for (var i = 0; i < data.length; i++) {
+			if (data[i]['type'] < minType) minType = data[i]['type']
+		}
+		tocHtml = tocHtml + '<div class="toc-con" style="left:' + padNum + 'px" id="toc-con">'	// 渲染
+		tocHtml = tocHtml + '<div style="height:calc(100vh - 70px);overflow-y:scroll;" ><lu>'
+		for (var i = 0; i < data.length; i++) {
+			let k = minType
+			let itemType = data[i]['type']
+			let isPadding = ''
+			let isBold = ['', '']
 
-           if (itemType != judgeN) isPadding = 'style="padding-top:' + chilPad + 'px"'
-           tocHtml = tocHtml + '<li ' + isPadding + ' id="to' + i + '" title="' + data[i]['content'] + '" >'
-           if (itemType == minType) {
-               isBold[0] = '<b>'
-               isBold[1] = '</b>'
-           }
-           while (k < itemType) {
-               tocHtml = tocHtml + '&nbsp;&nbsp;&nbsp;&nbsp;'
-               k++
-           }
-           tocHtml = tocHtml + isBold[0] + data[i]['content'] + isBold[1] + '</li>'
-           judgeN = itemType
-       }
-       tocHtml = tocHtml + '</lu></div></div>'
-       $logcon.before(tocHtml)
+			if (itemType != judgeN) isPadding = 'style="padding-top:' + chilPad + 'px"'
+			tocHtml = tocHtml + '<li ' + isPadding + ' id="to' + i + '" title="' + data[i]['content'] + '" >'
+			if (itemType == minType) {
+				isBold[0] = '<b>'
+				isBold[1] = '</b>'
+			}
+			while (k < itemType) {
+				tocHtml = tocHtml + '&nbsp;&nbsp;&nbsp;&nbsp;'
+				k++
+			}
+			tocHtml = tocHtml + isBold[0] + data[i]['content'] + isBold[1] + '</li>'
+			judgeN = itemType
+		}
+		tocHtml = tocHtml + '</lu></div></div>'
+		$logcon.before(tocHtml)
 
-       function tocSetListen(){  // 批量添加监听事件
-           for (var i = 0; i < data.length; i++) {
-               let tempPos = myBlog.tocArray[i]["pos"]
-               $('#to' + i).off("click");
-               $('#to' + i).bind("click", function () {
-                   window.onscroll = function () {
-                       tocSetPos()
-                   }
-                   $('body,html').animate({scrollTop: tempPos}, 300, function () {
-                       tocGetPos()
-                       window.onscroll = function () {
-                           tocSetPos();
-                           tocGetPos()
-                       }
-                   })
-               })
-           }
-       }
+		function tocSetListen(){  // 批量添加监听事件
+			for (var i = 0; i < data.length; i++) {
+				let tempPos = myBlog.tocArray[i]["pos"]
+				$('#to' + i).off("click");
+				$('#to' + i).bind("click", function () {
+					window.onscroll = function () {
+						tocSetPos()
+					}
+					$('body,html').animate({scrollTop: tempPos}, 300, function () {
+						tocGetPos()
+						window.onscroll = function () {
+							tocSetPos();
+							tocGetPos()
+						}
+					})
+				})
+			}
+		}
 
-       function tocSetPos() {  // 判断位置和设置定位样式
-           let articleTop = 200
-           
-           if (document.documentElement.scrollTop > articleTop) {
-               $("#toc-con").css("position", "fixed")
-                   .css("top", "0px")
-           } else {
-               $("#toc-con").css("position", "absolute")
-                   .css("top", articleTop + "px")
-           }
-       }
+		function tocSetPos() {  // 判断位置和设置定位样式
+			let articleTop = 200
+			
+			if (document.documentElement.scrollTop > articleTop) {
+				$("#toc-con").css("position", "fixed")
+					.css("top", "0px")
+			} else {
+				$("#toc-con").css("position", "absolute")
+					.css("top", articleTop + "px")
+			}
+		}
 
-       function tocGetPos() {  // 获取位置并改变指定标题颜色
-           let $tempItem
-           let dataArr = myBlog.tocArray
+		function tocGetPos() {  // 获取位置并改变指定标题颜色
+			let $tempItem
+			let dataArr = myBlog.tocArray
 
-           $('#toc-con li').css('color', 'unset').attr('isRed', 'n')
-           for (var i = 0; i < dataArr.length; i++) {
-               let winPos = document.documentElement.scrollTop + 30
-               if (winPos > dataArr[i]['pos']) $tempItem = $('#to' + i)
-           }
-           if ($tempItem){
-               $tempItem.css('color', 'red').attr('isRed', 'y')
-           } else {
-               return
-           }
-           let redScreenPos = $("li[isred='y']").offset().top - document.documentElement.scrollTop
-           let tocHeight = $("#toc-con div").outerHeight()
-           let tocPos = $("#toc-con div").scrollTop()
+			$('#toc-con li').css('color', 'unset').attr('isRed', 'n')
+			for (var i = 0; i < dataArr.length; i++) {
+				let winPos = document.documentElement.scrollTop + 30
+				if (winPos > dataArr[i]['pos']) $tempItem = $('#to' + i)
+			}
+			if ($tempItem){
+				$tempItem.css('color', 'red').attr('isRed', 'y')
+			} else {
+				return
+			}
+			let redScreenPos = $("li[isred='y']").offset().top - document.documentElement.scrollTop
+			let tocHeight = $("#toc-con div").outerHeight()
+			let tocPos = $("#toc-con div").scrollTop()
 
-           if (redScreenPos > tocHeight) {  // 根据文章阅读位置来调整 toc 滚动条位置
-               $("#toc-con div").scrollTop($("li[isred='y']").offset().top - tocHeight)
-           } else if (redScreenPos < 0) {
-               $("#toc-con div").scrollTop(tocPos + redScreenPos - (tocHeight / 2))
-           } else {
-               if (redScreenPos > (tocHeight / 2)) $("#toc-con div").scrollTop(tocPos + 10)
-               if (redScreenPos < (tocHeight / 2 - 40)) $("#toc-con div").scrollTop(tocPos - 10)
-           }
-       }
+			if (redScreenPos > tocHeight) {  // 根据文章阅读位置来调整 toc 滚动条位置
+				$("#toc-con div").scrollTop($("li[isred='y']").offset().top - tocHeight)
+			} else if (redScreenPos < 0) {
+				$("#toc-con div").scrollTop(tocPos + redScreenPos - (tocHeight / 2))
+			} else {
+				if (redScreenPos > (tocHeight / 2)) $("#toc-con div").scrollTop(tocPos + 10)
+				if (redScreenPos < (tocHeight / 2 - 40)) $("#toc-con div").scrollTop(tocPos - 10)
+			}
+		}
 
-       tocSetListen()
-       tocSetPos()
-       window.onscroll = function () {
-           tocSetPos();
-           tocGetPos()
-       }  // 滚轮事件
-       $('#toc-con div').mouseover(function () {  // 根据鼠标位置来调整滚轮事件
-           window.onscroll = function () {
-               tocSetPos()
-           }
-       }).mouseout(function () {
-           window.onscroll = function () {
-               tocSetPos();
-               tocGetPos()
-           }
-       })
+		tocSetListen()
+		tocSetPos()
+		window.onscroll = function () {
+			tocSetPos();
+			tocGetPos()
+		}  // 滚轮事件
+		$('#toc-con div').mouseover(function () {  // 根据鼠标位置来调整滚轮事件
+			window.onscroll = function () {
+				tocSetPos()
+			}
+		}).mouseout(function () {
+			window.onscroll = function () {
+				tocSetPos();
+				tocGetPos()
+			}
+		})
 
-       setInterval(function(){  // 每 1.5 秒刷新一次 toc 监听事件和 toc 目录坐标
-           tocSetListen()
-           myBlog.tocSetArray()
-       }, 1500)
-   },/**
-    * toc 目录移动端的部分设置
-    */
-   tocMobileSet: function () {
-       if (window.outerWidth > 1275) return
-       $(".toc-con").toggle()
-       $("[toc-date='title']").append('<a class="toc-link">[目录]</a>')
+		setInterval(function(){  // 每 1.5 秒刷新一次 toc 监听事件和 toc 目录坐标
+			tocSetListen()
+			myBlog.tocSetArray()
+		}, 1500)
+	},/**
+	* toc 目录移动端的部分设置
+	*/
+	tocMobileSet: function () {
+		if (window.outerWidth > 1275) return
+		$(".toc-con").toggle()
+		$("[toc-date='title']").append('<a class="toc-link">[目录]</a>')
 
-       $(".toc-link").click(function (e) {  // 添加监听事件
-           $(".toc-con").show()
-           e.stopPropagation()  // 阻止事件冒泡
-       }),
+		$(".toc-link").click(function (e) {  // 添加监听事件
+			$(".toc-con").show()
+			e.stopPropagation()  // 阻止事件冒泡
+		}),
 
-       $("html").click(function (e) {
-           if($(".toc-con") && $(".toc-con").css("display") == "block") {
-               $(".toc-con").hide()
-           }
-           e.stopPropagation() 
-       })
-   }
+		$("html").click(function (e) {
+			if($(".toc-con") && $(".toc-con").css("display") == "block") {
+				$(".toc-con").hide()
+			}
+			e.stopPropagation() 
+		})
+	}
 }
 
 /**
  * 事件监听
  */
 $(document).ready(function () {
-    myBlog.init()
+	myBlog.init()
 
-    $(".com-reply").click(function () {
-        myBlog.comReply($(this))
-    }),
+	$(".com-reply").click(function () {
+		myBlog.comReply($(this))
+	}),
 
-    $(".cancel-reply").click(function () {
-        myBlog.cancelReply($(this))
-    }),
+	$(".cancel-reply").click(function () {
+		myBlog.cancelReply($(this))
+	}),
 
-    $(".blog-header-toggle").click(function () {
-        myBlog.navToggle($(this))
-    }),
+	$(".blog-header-toggle").click(function () {
+		myBlog.navToggle($(this))
+	}),
 
-    $(".has-down").mouseenter(function () {
-        myBlog.calMargin($(this))
-    }),
+	$(".has-down").mouseenter(function () {
+		myBlog.calMargin($(this))
+	}),
 
-    $("#captcha").click(function () {
-        myBlog.captchaRefresh($(this))
-    }),
+	$("#captcha").click(function () {
+		myBlog.captchaRefresh($(this))
+	}),
 
-    $('#comment_submit[type="button"], #close-modal').click(function () {
-        myBlog.comSubmitTip('judge')
-        if (myBlog.comSubmitTip()) {  // 在显示评论的验证码模态框前，先校验一下评论区内容
-            myBlog.viewModal()
-        }
-    }),
+	$('#comment_submit[type="button"], #close-modal').click(function () {
+		myBlog.comSubmitTip('judge')
+		if (myBlog.comSubmitTip()) {  // 在显示评论的验证码模态框前，先校验一下评论区内容
+			myBlog.viewModal()
+		}
+	}),
 
-    $(".form-control").blur(function () {
-        myBlog.comSubmitTip('judge')
-    }),
+	$(".form-control").blur(function () {
+		myBlog.comSubmitTip('judge')
+	}),
 
-    $(".markdown img").click(function () {
-        myBlog.toggleImgSrc($(this))
-    }),
+	$(".markdown img").click(function () {
+		myBlog.toggleImgSrc($(this))
+	}),
 
-    $("#archive").change(function () {
-        myBlog.jumpLink($(this))
-    })
+	$("#archive").change(function () {
+		myBlog.jumpLink($(this))
+	})
 })

--- a/content/templates/default/log_list.php
+++ b/content/templates/default/log_list.php
@@ -7,54 +7,53 @@ if (!defined('EMLOG_ROOT')) {
 }
 ?>
 <main class="container blog-container">
-    <div class="row">
-        <div class="column-big"> 
+	<div class="row">
+		<div class="column-big"> 
 			<?php doAction('index_loglist_top');
 			if (!empty($logs)):
 				foreach ($logs as $value):
 					?>
-                    <div class="shadow-theme bottom-5">
+					<div class="shadow-theme bottom-5">
 						<?php if (!empty($value['log_cover'])) : ?>
-                            <div class="loglist-cover">
-                                <img src="<?= $value['log_cover'] ?>" class="rea-width" data-action="zoom">
-                            </div>
+							<div class="loglist-cover">
+								<img src="<?= $value['log_cover'] ?>" class="rea-width" data-action="zoom">
+							</div>
 						<?php endif ?>
-                        <div class="card-padding loglist-body">
-                            <h3 class="card-title">
-                                <a href="<?= $value['log_url'] ?>" class="loglist-title"><?= $value['log_title'] ?></a>
+						<div class="card-padding loglist-body">
+							<h3 class="card-title">
+								<a href="<?= $value['log_url'] ?>" class="loglist-title"><?= $value['log_title'] ?></a>
 								<?php topflg($value['top'], $value['sortop'], isset($sortid) ? $sortid : '') ?>
-                                <?php bloglist_sort($value['logid']) ?>
-                            </h3>
-                            <div class="loglist-content markdown"><?= $value['log_description'] ?></div>
-                            <div class="loglist-tag"><?php blog_tag($value['logid']) ?></div>
-                        </div>
-                        <hr class="list-line"/>
-                        <div class="row info-row">
-                            <div class="log-info">
+								<?php bloglist_sort($value['logid']) ?>
+							</h3>
+							<div class="loglist-content markdown"><?= $value['log_description'] ?></div>
+							<div class="loglist-tag"><?php blog_tag($value['logid']) ?></div>
+						</div>
+						<hr class="list-line"/>
+						<div class="row info-row">
+							<div class="log-info">
 								<?php blog_author($value['author']) ?>&nbsp;发布于&nbsp;
-                                <?= date('Y-n-j', $value['date']) ?>&nbsp;
-                                <span class="mh"><?= date('H:i', $value['date']) ?></span>
-                                <?php editflg($value['logid'], $value['author']) ?>
-                            </div>
-                            <div class="log-count">
-                                <a href="<?= $value['log_url'] ?>#comments">评论(<?= $value['comnum'] ?>)&nbsp;</a>
-                                <a href="<?= $value['log_url'] ?>">浏览(<?= $value['views'] ?>)</a>
-                            </div>
-                        </div>
-                    </div>
+								<?= date('Y-n-j', $value['date']) ?>&nbsp;
+								<span class="mh"><?= date('H:i', $value['date']) ?></span>
+								<?php editflg($value['logid'], $value['author']) ?>
+							</div>
+							<div class="log-count">
+								<a href="<?= $value['log_url'] ?>#comments">评论(<?= $value['comnum'] ?>)&nbsp;</a>
+								<a href="<?= $value['log_url'] ?>">浏览(<?= $value['views'] ?>)</a>
+							</div>
+						</div>
+					</div>
 				<?php
 				endforeach;
 			else:
 				?>
-                <p>抱歉，暂时还没有内容。</p>
+				<p>抱歉，暂时还没有内容。</p>
 			<?php endif ?>
-            <div class="pagination bottom-5">
+			<div class="pagination bottom-5">
 				<?= $page_url ?>
-            </div>
-        </div>
+			</div>
+		</div>
 		<?php include View::getView('side') ?>
-    </div>
+	</div>
 </main>
 
 <?php include View::getView('footer') ?>
- 

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -15,16 +15,16 @@ function widget_link($title) {
 	$link_cache = $CACHE->readCache('link');
 	//if (!blog_tool_ishome()) return;#只在首页显示友链去掉双斜杠注释即可
 	?>
-    <div class="widget shadow-theme">
-        <div class="widget-title">
-            <h3><?= $title ?></h3>
-        </div>
-        <ul class="widget-list no-margin-bottom unstyle-li">
+	<div class="widget shadow-theme">
+		<div class="widget-title">
+			<h3><?= $title ?></h3>
+		</div>
+		<ul class="widget-list no-margin-bottom unstyle-li">
 			<?php foreach ($link_cache as $value): ?>
-                <li><a href="<?= $value['url'] ?>" target="_blank"><?= $value['link'] ?></a></li>
+				<li><a href="<?= $value['url'] ?>" target="_blank"><?= $value['link'] ?></a></li>
 			<?php endforeach ?>
-        </ul>
-    </div>
+		</ul>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -34,35 +34,35 @@ function widget_blogger($title) {
 	global $CACHE;
 	$user_cache = $CACHE->readCache('user');
 	$name = $user_cache[1]['mail'] != '' ? "<a href=\"mailto:" . $user_cache[1]['mail'] . "\">" . $user_cache[1]['name'] . "</a>" : $user_cache[1]['name'] ?>
-    <div class="widget shadow-theme">
-        <div class="widget-title">
-            <h3><?= $title ?></h3>
-        </div>
-        <div class="unstyle-li bloggerinfo">
+	<div class="widget shadow-theme">
+		<div class="widget-title">
+			<h3><?= $title ?></h3>
+		</div>
+		<div class="unstyle-li bloggerinfo">
 			<?php if (!empty($user_cache[1]['photo']['src'])): ?>
-                <div>
-                    <img class='bloggerinfo-img' src="<?= BLOG_URL . $user_cache[1]['photo']['src'] ?>" alt="blogger"/>
-                </div>
+				<div>
+					<img class='bloggerinfo-img' src="<?= BLOG_URL . $user_cache[1]['photo']['src'] ?>" alt="blogger"/>
+				</div>
 			<?php endif ?>
-            <div class='bloginfo-name'><b><?= $name ?></b></div>
-            <div class='bloginfo-descript'><?= $user_cache[1]['des'] ?></div>
-        </div>
-    </div>
+			<div class='bloginfo-name'><b><?= $name ?></b></div>
+			<div class='bloginfo-descript'><?= $user_cache[1]['des'] ?></div>
+		</div>
+	</div>
 <?php } ?>
 <?php
 /**
  * 侧边栏：日历
  */
 function widget_calendar($title) { ?>
-    <div class="widget shadow-theme">
-        <div class="widget-title m">
-            <h3><?= $title ?></h3>
-        </div>
-        <div class="unstyle-li">
-            <div id="calendar"></div>
-            <script>sendinfo('<?= Calendar::url() ?>', 'calendar');</script>
-        </div>
-    </div>
+	<div class="widget shadow-theme">
+		<div class="widget-title m">
+			<h3><?= $title ?></h3>
+		</div>
+		<div class="unstyle-li">
+			<div id="calendar"></div>
+			<script>sendinfo('<?= Calendar::url() ?>', 'calendar');</script>
+		</div>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -71,17 +71,17 @@ function widget_calendar($title) { ?>
 function widget_tag($title) {
 	global $CACHE;
 	$tag_cache = $CACHE->readCache('tags') ?>
-    <div class="widget shadow-theme">
-        <div class="widget-title m">
-            <h3><?= $title ?></h3>
-        </div>
-        <div class="unstyle-li tag-container">
+	<div class="widget shadow-theme">
+		<div class="widget-title m">
+			<h3><?= $title ?></h3>
+		</div>
+		<div class="unstyle-li tag-container">
 			<?php foreach ($tag_cache as $value): ?>
-                <span style="font-size:<?= $value['fontsize'] ?>pt; line-height:30px;">
-            <a href="<?= Url::tag($value['tagurl']) ?>" title="<?= $value['usenum'] ?> 篇文章" class='tags-side'><?= $value['tagname'] ?></a></span>
+				<span style="font-size:<?= $value['fontsize'] ?>pt; line-height:30px;">
+			<a href="<?= Url::tag($value['tagurl']) ?>" title="<?= $value['usenum'] ?> 篇文章" class='tags-side'><?= $value['tagname'] ?></a></span>
 			<?php endforeach ?>
-        </div>
-    </div>
+		</div>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -90,35 +90,35 @@ function widget_tag($title) {
 function widget_sort($title) {
 	global $CACHE;
 	$sort_cache = $CACHE->readCache('sort') ?>
-    <div class="widget shadow-theme">
-        <div class="widget-title m">
-            <h3><?= $title ?></h3>
-        </div>
-        <ul class="unstyle-li log-classify-f">
+	<div class="widget shadow-theme">
+		<div class="widget-title m">
+			<h3><?= $title ?></h3>
+		</div>
+		<ul class="unstyle-li log-classify-f">
 			<?php
 			foreach ($sort_cache as $value):
 				if ($value['pid'] != 0) continue;
 				?>
-                <li>
-                    <a href="<?= Url::sort($value['sid']) ?>"><?= $value['sortname'] ?>&nbsp;&nbsp;<?= (($value['lognum']) > 0) ? '(' . ($value['lognum']) . ')' : '' ?></a>
+				<li>
+					<a href="<?= Url::sort($value['sid']) ?>"><?= $value['sortname'] ?>&nbsp;&nbsp;<?= (($value['lognum']) > 0) ? '(' . ($value['lognum']) . ')' : '' ?></a>
 					<?php if (!empty($value['children'])): ?>
-                        <ul class="log-classify-c">
+						<ul class="log-classify-c">
 							<?php
 							$children = $value['children'];
 							foreach ($children as $key):
 								$value = $sort_cache[$key];
 								?>
-                                <li>
-                                    <a href="<?= Url::sort($value['sid']) ?>">--&nbsp;&nbsp;<?= $value['sortname'] ?>
-                                        &nbsp;&nbsp;(<?= $value['lognum'] ?>)</a>
-                                </li>
+								<li>
+									<a href="<?= Url::sort($value['sid']) ?>">--&nbsp;&nbsp;<?= $value['sortname'] ?>
+										&nbsp;&nbsp;(<?= $value['lognum'] ?>)</a>
+								</li>
 							<?php endforeach ?>
-                        </ul>
+						</ul>
 					<?php endif ?>
-                </li>
+				</li>
 			<?php endforeach ?>
-        </ul>
-    </div>
+		</ul>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -129,28 +129,28 @@ function widget_newcomm($title) {
 	$com_cache = $CACHE->readCache('comment');
 	$isGravatar = Option::get('isgravatar');
 	?>
-    <div class="widget shadow-theme">
-        <div class="widget-title">
-            <h3><?= $title ?></h3>
-        </div>
-        <hr>
-        <ul class="unstyle-li">
+	<div class="widget shadow-theme">
+		<div class="widget-title">
+			<h3><?= $title ?></h3>
+		</div>
+		<hr>
+		<ul class="unstyle-li">
 			<?php
 			foreach ($com_cache as $value):
 				$url = Url::comment($value['gid'], $value['page'], $value['cid']);
 				?>
-                <li class="comment-info">
+				<li class="comment-info">
 					<?php if ($isGravatar == 'y'): ?>
-                        <img class='comment-info_img' src="<?= getGravatar($value['mail']) ?>" alt="commentator"/>
+						<img class='comment-info_img' src="<?= getGravatar($value['mail']) ?>" alt="commentator"/>
 					<?php endif ?>
-                    <span class='comm-lates-name'><?= $value['name'] ?></span>
-                    <span class='logcom-latest-time'><?= smartDate($value['date']) ?></span><br/>
-                    <a href="<?= $url ?>" style="color: #989898;"><?= $value['content'] ?></a>
-                    <hr>
-                </li>
+					<span class='comm-lates-name'><?= $value['name'] ?></span>
+					<span class='logcom-latest-time'><?= smartDate($value['date']) ?></span><br/>
+					<a href="<?= $url ?>" style="color: #989898;"><?= $value['content'] ?></a>
+					<hr>
+				</li>
 			<?php endforeach ?>
-        </ul>
-    </div>
+		</ul>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -160,16 +160,16 @@ function widget_newlog($title) {
 	global $CACHE;
 	$newLogs_cache = $CACHE->readCache('newlog');
 	?>
-    <div class="widget shadow-theme">
-        <div class="widget-title m">
-            <h3><?= $title ?></h3>
-        </div>
-        <ul class="unstyle-li">
+	<div class="widget shadow-theme">
+		<div class="widget-title m">
+			<h3><?= $title ?></h3>
+		</div>
+		<ul class="unstyle-li">
 			<?php foreach ($newLogs_cache as $value): ?>
-                <li class="blog-lates"><a href="<?= Url::log($value['gid']) ?>"><?= $value['title'] ?></a></li>
+				<li class="blog-lates"><a href="<?= Url::log($value['gid']) ?>"><?= $value['title'] ?></a></li>
 			<?php endforeach ?>
-        </ul>
-    </div>
+		</ul>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -179,33 +179,33 @@ function widget_hotlog($title) {
 	$index_hotlognum = Option::get('index_hotlognum');
 	$Log_Model = new Log_Model();
 	$hotLogs = $Log_Model->getHotLog($index_hotlognum) ?>
-    <div class="widget shadow-theme">
-        <div class="widget-title m">
-            <h3><?= $title ?></h3>
-        </div>
-        <ul class="unstyle-li">
+	<div class="widget shadow-theme">
+		<div class="widget-title m">
+			<h3><?= $title ?></h3>
+		</div>
+		<ul class="unstyle-li">
 			<?php foreach ($hotLogs as $value): ?>
-                <li class="blog-hot"><a href="<?= Url::log($value['gid']) ?>"><?= $value['title'] ?></a></li>
+				<li class="blog-hot"><a href="<?= Url::log($value['gid']) ?>"><?= $value['title'] ?></a></li>
 			<?php endforeach ?>
-        </ul>
-    </div>
+		</ul>
+	</div>
 <?php } ?>
 <?php
 /**
  * 侧边栏：搜索
  */
 function widget_search($title) { ?>
-    <div class="widget shadow-theme">
-        <div class="widget-title">
-            <h3><?= $title ?></h3>
-        </div>
-        <div class="unstyle-li" style="text-align: center;">
-            <form name="keyform" method="get" action="<?= BLOG_URL ?>index.php">
-                <input name="keyword" class="search form-control" autocomplete="off" type="text"/>
-                <input type="submit" value="搜索">
-            </form>
-        </div>
-    </div>
+	<div class="widget shadow-theme">
+		<div class="widget-title">
+			<h3><?= $title ?></h3>
+		</div>
+		<div class="unstyle-li" style="text-align: center;">
+			<form name="keyform" method="get" action="<?= BLOG_URL ?>index.php">
+				<input name="keyword" class="search form-control" autocomplete="off" type="text"/>
+				<input type="submit" value="搜索">
+			</form>
+		</div>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -216,30 +216,30 @@ function widget_archive($title) {
 	global $CACHE;
 	$record_cache = $CACHE->readCache('record');
 	?>
-    <div class="widget shadow-theme">
-        <div class="widget-title m">
-            <h3><?= $title ?></h3>
-        </div>
-        <select id="archive" class="archive">
+	<div class="widget shadow-theme">
+		<div class="widget-title m">
+			<h3><?= $title ?></h3>
+		</div>
+		<select id="archive" class="archive">
 			<?php foreach ($record_cache as $value): ?>
-                <option value="<?= Url::record($value['date']) ?>"><?= $value['record'] ?>&nbsp;(<?= $value['lognum'] ?>)</option>
-            <?php endforeach ?>
-        </select>
-    </div>
+				<option value="<?= Url::record($value['date']) ?>"><?= $value['record'] ?>&nbsp;(<?= $value['lognum'] ?>)</option>
+			<?php endforeach ?>
+		</select>
+	</div>
 <?php } ?>
 <?php
 /**
  * 侧边栏：自定义组件
  */
 function widget_custom_text($title, $content) { ?>
-    <div class="widget shadow-theme">
-        <div class="widget-title m">
-            <h3><?= $title ?></h3>
-        </div>
-        <ul class="unstyle-li">
+	<div class="widget shadow-theme">
+		<div class="widget-title m">
+			<h3><?= $title ?></h3>
+		</div>
+		<ul class="unstyle-li">
 			<?= $content ?>
-        </ul>
-    </div>
+		</ul>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -249,8 +249,8 @@ function blog_navi() {
 	global $CACHE;
 	$navi_cache = $CACHE->readCache('navi');
 	?>
-    <div class="blog-header-nav" id="navbarResponsive">
-        <ul class="nav-list">
+	<div class="blog-header-nav" id="navbarResponsive">
+		<ul class="nav-list">
 			<?php
 			foreach ($navi_cache as $value):
 				if ($value['pid'] != 0) {
@@ -258,8 +258,8 @@ function blog_navi() {
 				}
 				if ($value['url'] == 'admin' && (!User::isVistor())):
 					?>
-                    <li class="list-item list-menu"><a href="<?= BLOG_URL ?>admin/" class="nav-link">管理</a></li>
-                    <li class="list-item list-menu"><a href="<?= BLOG_URL ?>admin/account.php?action=logout" class="nav-link">退出</a></li>
+					<li class="list-item list-menu"><a href="<?= BLOG_URL ?>admin/" class="nav-link">管理</a></li>
+					<li class="list-item list-menu"><a href="<?= BLOG_URL ?>admin/account.php?action=logout" class="nav-link">退出</a></li>
 					<?php
 					continue;
 				endif;
@@ -268,31 +268,31 @@ function blog_navi() {
 				$current_tab = BLOG_URL . trim(Dispatcher::setPath(), '/') == $value['url'] ? 'active' : '';
 				?>
 				<?php if (!empty($value['children']) || !empty($value['childnavi'])) : ?>
-                <li class="list-item list-menu">
+				<li class="list-item list-menu">
 					<?php if (!empty($value['children'])): ?>
-                        <a class="nav-link has-down" id="nav_link" href="<?= $value['url'] ?>" <?= $newtab ?>><?= $value['naviname'] ?> <b class="caret"></b></a>
-                        <ul class="dropdown-menus">
+						<a class="nav-link has-down" id="nav_link" href="<?= $value['url'] ?>" <?= $newtab ?>><?= $value['naviname'] ?> <b class="caret"></b></a>
+						<ul class="dropdown-menus">
 							<?php foreach ($value['children'] as $row) {
 								echo '<li class="list-item list-menu"><a class="nav-link" href="' . Url::sort($row['sid']) . '">' . $row['sortname'] . '</a></li>';
 							} ?>
-                        </ul>
+						</ul>
 					<?php endif ?>
 					<?php if (!empty($value['childnavi'])) : ?>
-                        <a class='nav-link has-down' id="nav_link" <?= $newtab ?> ><?= $value['naviname'] ?><b class="caret"></b></a>
-                        <ul class="dropdown-menus">
+						<a class='nav-link has-down' id="nav_link" <?= $newtab ?> ><?= $value['naviname'] ?><b class="caret"></b></a>
+						<ul class="dropdown-menus">
 							<?php foreach ($value['childnavi'] as $row) {
 								$newtab = $row['newtab'] == 'y' ? 'target="_blank"' : '';
 								echo '<li class="list-item list-menu"><a class="nav-link" href="' . $row['url'] . "\" $newtab >" . $row['naviname'] . '</a></li>';
 							} ?>
-                        </ul>
+						</ul>
 					<?php endif ?>
-                </li>
+				</li>
 			<?php else: ?>
-                <li class="list-item list-menu"><a class="nav-link" href="<?= $value['url'] ?>" <?= $newtab ?>><?= $value['naviname'] ?></a></li>
+				<li class="list-item list-menu"><a class="nav-link" href="<?= $value['url'] ?>" <?= $newtab ?>><?= $value['naviname'] ?></a></li>
 			<?php endif ?>
 			<?php endforeach ?>
-        </ul>
-    </div>
+		</ul>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -328,9 +328,9 @@ function blog_sort($blogid) {
 	$log_cache_sort = $CACHE->readCache('logsort');
 	?>
 	<?php if (!empty($log_cache_sort[$blogid])) { ?>
-        <a href="<?= Url::sort($log_cache_sort[$blogid]['id']) ?>" title="分类：<?= $log_cache_sort[$blogid]['name'] ?>"><?= $log_cache_sort[$blogid]['name'] ?></a>
+		<a href="<?= Url::sort($log_cache_sort[$blogid]['id']) ?>" title="分类：<?= $log_cache_sort[$blogid]['name'] ?>"><?= $log_cache_sort[$blogid]['name'] ?></a>
 	<?php } else { ?>
-        <a href="#" title="未分类">无</a>
+		<a href="#" title="未分类">无</a>
 	<?php }
 } ?>
 <?php
@@ -342,9 +342,9 @@ function bloglist_sort($blogid) {
 	$log_cache_sort = $CACHE->readCache('logsort');
 	?>
 	<?php if (!empty($log_cache_sort[$blogid])) { ?>
-        <span class="loglist-sort">
-            <a href="<?= Url::sort($log_cache_sort[$blogid]['id']) ?>" title="分类：<?= $log_cache_sort[$blogid]['name'] ?>"><?= $log_cache_sort[$blogid]['name'] ?></a>
-        </span>
+		<span class="loglist-sort">
+			<a href="<?= Url::sort($log_cache_sort[$blogid]['id']) ?>" title="分类：<?= $log_cache_sort[$blogid]['name'] ?>"><?= $log_cache_sort[$blogid]['name'] ?></a>
+		</span>
 	<?php }
 } ?>
 <?php
@@ -399,10 +399,10 @@ function blog_author($uid) {
 function neighbor_log($neighborLog) {
 	extract($neighborLog) ?>
 	<?php if ($prevLog): ?>
-        <span class="prev-log"><a href="<?= Url::log($prevLog['gid']) ?>" title="<?= $prevLog['title'] ?>">上一篇</a></span>
+		<span class="prev-log"><a href="<?= Url::log($prevLog['gid']) ?>" title="<?= $prevLog['title'] ?>">上一篇</a></span>
 	<?php endif ?>
 	<?php if ($nextLog): ?>
-        <span class="next-log"><a href="<?= Url::log($nextLog['gid']) ?>" title="<?= $nextLog['title'] ?>">下一篇</a></span>
+		<span class="next-log"><a href="<?= Url::log($nextLog['gid']) ?>" title="<?= $nextLog['title'] ?>">下一篇</a></span>
 	<?php endif ?>
 <?php } ?>
 <?php
@@ -412,7 +412,7 @@ function neighbor_log($neighborLog) {
 function blog_comments($comments) {
 	extract($comments);
 	if ($commentStacks): ?>
-        <div class="comment-header"><b>评论：</b></div>
+		<div class="comment-header"><b>评论：</b></div>
 	<?php endif ?>
 	<?php
 	$isGravatar = Option::get('isgravatar');
@@ -421,28 +421,28 @@ function blog_comments($comments) {
 		$comment = $comments[$cid];
 		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
 		?>
-        <div class="comment" id="<?= $comment['cid'] ?>">
+		<div class="comment" id="<?= $comment['cid'] ?>">
 			<?php if ($isGravatar == 'y'): ?>
-                <div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>"/></div>
-                <div class="comment-infos">
-                    <div class="arrow"></div>
-                    <b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
-                    <div class="comment-content"><?= $comment['content'] ?></div>
-                    <div class="comment-reply"><a class="com-reply">回复</a></div>
-                </div>
+				<div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>"/></div>
+				<div class="comment-infos">
+					<div class="arrow"></div>
+					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
+					<div class="comment-content"><?= $comment['content'] ?></div>
+					<div class="comment-reply"><a class="com-reply">回复</a></div>
+				</div>
 			<?php else: ?>
-                <div class="comment-infos-unGravatar">
-                    <b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
-                    <div class="comment-content"><?= $comment['content'] ?></div>
-                    <div class="comment-reply"><a class="com-reply">回复</a></div>
-                </div>
+				<div class="comment-infos-unGravatar">
+					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
+					<div class="comment-content"><?= $comment['content'] ?></div>
+					<div class="comment-reply"><a class="com-reply">回复</a></div>
+				</div>
 			<?php endif ?>
 			<?php blog_comments_children($comments, $comment['children']) ?>
-        </div>
+		</div>
 	<?php endforeach ?>
-    <div id="pagenavi">
+	<div id="pagenavi">
 		<?= $commentPageUrl ?>
-    </div>
+	</div>
 <?php } ?>
 <?php
 /**
@@ -454,28 +454,28 @@ function blog_comments_children($comments, $children) {
 		$comment = $comments[$child];
 		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
 		?>
-        <div class="comment comment-children" id="<?= $comment['cid'] ?>">
+		<div class="comment comment-children" id="comment-<?= $comment['cid'] ?>">
 			<?php if ($isGravatar == 'y'): ?>
-                <div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>" alt="commentator"/></div>
-                <div class="comment-infos">
-                    <div class="arrow"></div>
-                    <b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
-                    <div class="comment-content"><?= $comment['content'] ?></div>
+				<div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>" alt="commentator"/></div>
+				<div class="comment-infos">
+					<div class="arrow"></div>
+					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
+					<div class="comment-content"><?= $comment['content'] ?></div>
 					<?php if ($comment['level'] < 4): ?>
-                        <div class="comment-reply"><a class="com-reply">回复</a>
-                        </div><?php endif ?>
-                </div>
+						<div class="comment-reply"><a class="com-reply">回复</a>
+						</div><?php endif ?>
+				</div>
 			<?php else: ?>
-                <div class="comment-infos-unGravatar">
-                    <b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
-                    <div class="comment-content"><?= $comment['content'] ?></div>
+				<div class="comment-infos-unGravatar">
+					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
+					<div class="comment-content"><?= $comment['content'] ?></div>
 					<?php if ($comment['level'] < 4): ?>
-                        <div class="comment-reply"><a class="com-reply">回复</a>
-                        </div><?php endif ?>
-                </div>
+						<div class="comment-reply"><a class="com-reply">回复</a>
+						</div><?php endif ?>
+				</div>
 			<?php endif ?>
 			<?php blog_comments_children($comments, $comment['children']) ?>
-        </div>
+		</div>
 	<?php endforeach ?>
 <?php } ?>
 <?php
@@ -485,54 +485,54 @@ function blog_comments_children($comments, $children) {
 function blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allow_remark) {
 	$isNeedChinese = Option::get('comment_needchinese');
 	if ($allow_remark == 'y'): ?>
-        <div id="comment-place">
-            <div class="comment-post" id="comment-post">
-                <div class="cancel-reply" id="cancel-reply" style="display:none"><a>取消回复</a></div>
-                <form class="commentform" method="post" name="commentform" action="<?= BLOG_URL ?>index.php?action=addcom" id="commentform"
-                      is-chinese="<?= $isNeedChinese ?>">
-                    <input type="hidden" name="gid" value="<?= $logid ?>"/>
-                    <textarea class="form-control log_comment" name="comment" id="comment" rows="10" tabindex="4" required></textarea>
+		<div id="comment-place">
+			<div class="comment-post" id="comment-post">
+				<div class="cancel-reply" id="cancel-reply" style="display:none"><a>取消回复</a></div>
+				<form class="commentform" method="post" name="commentform" action="<?= BLOG_URL ?>index.php?action=addcom" id="commentform"
+					  is-chinese="<?= $isNeedChinese ?>">
+					<input type="hidden" name="gid" value="<?= $logid ?>"/>
+					<textarea class="form-control log_comment" name="comment" id="comment" rows="10" tabindex="4" required></textarea>
 					<?php if (User::isVistor()): ?>
-                        <div class="comment-info" id="comment-info">
-                            <input class="form-control com_control comment-name" id="info_n" autocomplete="off" type="text" name="comname" maxlength="49"
-                                   value="<?= $ckname ?>" size="22"
-                                   tabindex="1" placeholder="昵称*" required/>
-                            <input class="form-control com_control comment-mail" id="info_m" autocomplete="off" type="text" name="commail" maxlength="128"
-                                   value="<?= $ckmail ?>" size="22"
-                                   tabindex="2" placeholder="邮件地址"/>
-                            <input class="form-control com_control comment-url" id="info_u" autocomplete="off" type="text" name="comurl" maxlength="128"
-                                   value="<?= $ckurl ?>" size="22"
-                                   tabindex="3" placeholder="个人主页"/>
-                        </div>
+						<div class="comment-info" id="comment-info">
+							<input class="form-control com_control comment-name" id="info_n" autocomplete="off" type="text" name="comname" maxlength="49"
+								   value="<?= $ckname ?>" size="22"
+								   tabindex="1" placeholder="昵称*" required/>
+							<input class="form-control com_control comment-mail" id="info_m" autocomplete="off" type="text" name="commail" maxlength="128"
+								   value="<?= $ckmail ?>" size="22"
+								   tabindex="2" placeholder="邮件地址"/>
+							<input class="form-control com_control comment-url" id="info_u" autocomplete="off" type="text" name="comurl" maxlength="128"
+								   value="<?= $ckurl ?>" size="22"
+								   tabindex="3" placeholder="个人主页"/>
+						</div>
 					<?php endif ?>
 
-                    <span class="com_submit_p">
-                        <input class="btn"<?php if ($verifyCode != "") { ?> type="button" data-toggle="modal" data-target="#myModal"<?php } else { ?> type="submit"<?php } ?>
-                               id="comment_submit" value="发布评论" tabindex="6"/>
-                    </span>
+					<span class="com_submit_p">
+						<input class="btn"<?php if ($verifyCode != "") { ?> type="button" data-toggle="modal" data-target="#myModal"<?php } else { ?> type="submit"<?php } ?>
+							   id="comment_submit" value="发布评论" tabindex="6"/>
+					</span>
 					<?php if ($verifyCode != "") { ?>
-                        <!-- 验证窗口 -->
-                        <div class="modal" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content" style="display: table-cell;">
-                                    <div class="modal-header" style="border-bottom: 0px;">
-                                        输入验证码
-                                    </div>
+						<!-- 验证窗口 -->
+						<div class="modal" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+							<div class="modal-dialog">
+								<div class="modal-content" style="display: table-cell;">
+									<div class="modal-header" style="border-bottom: 0px;">
+										输入验证码
+									</div>
 									<?= $verifyCode ?>
-                                    <div class="modal-footer" style="border-top: 0px;">
-                                        <button type="button" class="btn" id="close-modal" data-dismiss="modal">关闭</button>
-                                        <button type="submit" class="btn" id="comment_submit2">提交</button>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="lock-screen"></div>
-                        </div>
-                        <!-- 验证窗口(end) -->
+									<div class="modal-footer" style="border-top: 0px;">
+										<button type="button" class="btn" id="close-modal" data-dismiss="modal">关闭</button>
+										<button type="submit" class="btn" id="comment_submit2">提交</button>
+									</div>
+								</div>
+							</div>
+							<div class="lock-screen"></div>
+						</div>
+						<!-- 验证窗口(end) -->
 					<?php } ?>
-                    <input type="hidden" name="pid" id="comment-pid" value="0" tabindex="1"/>
-                </form>
-            </div>
-        </div>
+					<input type="hidden" name="pid" id="comment-pid" value="0" tabindex="1"/>
+				</form>
+			</div>
+		</div>
 	<?php endif ?>
 <?php } ?>
 <?php

--- a/content/templates/default/page.php
+++ b/content/templates/default/page.php
@@ -8,21 +8,20 @@ if (!defined('EMLOG_ROOT')) {
 ?>
 
 <article class="container blog-container">
-    <div class="row">
-        <div class="column-big log-con blog-container" id="page">
-            <h1 class="page-title"><?= $log_title ?></h1>
-            <div class="markdown">
-                <?= $log_content ?>
-            </div>
-		    <?php blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allow_remark) ?>
-            <?php blog_comments($comments) ?>
-        </div>
+	<div class="row">
+		<div class="column-big log-con " id="page">
+			<h1 class="page-title"><?= $log_title ?></h1>
+			<div class="markdown">
+				<?= $log_content ?>
+			</div>
+			<?php blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allow_remark) ?>
+			<?php blog_comments($comments) ?>
+		</div>
 		<?php
 		include View::getView('side');
 		?>
-    </div>
+	</div>
 </article>
 <?php
 include View::getView('footer');
 ?>
- 

--- a/content/templates/default/side.php
+++ b/content/templates/default/side.php
@@ -29,4 +29,3 @@ if (!defined('EMLOG_ROOT')) {
 	}
 	?>
 </div>
- 


### PR DESCRIPTION
过去，我本地的 vscode 默认缩进为 4 个空格，但 emlog/emlog 的大部分代码缩进一直是长度为 4 的 tab 制表符。

虽然在 vscode 上「4 个空格」与 「长度为 4 的 tab 制表符」看起来效果一样（正因如此，这个问题很难被发觉），但在 Github.com 上可不是，（在某些代码编辑器中也不是），很影响代码的美观程度。

所以为了美观起见 ，先将自带模版的所有缩进更改统一为长度为 4 的 tab 制表符（其他地方的代码，目前来看影响不大，因为每次提交时，大都会复制其他地方的缩进，粘贴过来以对齐），以后的 **规范** 也即：

**emlog 核心源码中所有缩进，为以长度为 4 的 tab 制表符。**