### PR TITLE
fix:模版的一些日常微调

### DIFF
--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -794,6 +794,18 @@ body {
 	border-radius: 0 3px 3px 0;
 	padding: 0
 }
+/* 评论区的 回复、取消回复 按钮 */
+.comment-replay-btn {
+	border: none;
+	cursor: pointer;
+	padding: 0;
+	background-color: unset
+}
+.comment-replay-btn:hover {
+	color: #f6607d;
+	text-decoration: underline;
+	transition: all 0.2s
+}
 
 /*文章条目中的部分样式
 ---------------------------------------------------*/
@@ -1216,6 +1228,12 @@ img.zoom-img {
 	font-size: 16px;
 	padding: 4px;
 	border-color: #ced4da
+}
+
+/* 文章列出页 编辑 链接的样式 
+---------------------------------------------------*/
+.loglist-article-edit a {
+	color: #929292
 }
 
 /* 一些适应各屏幕尺寸显示效果的样式

--- a/content/templates/default/log_list.php
+++ b/content/templates/default/log_list.php
@@ -34,11 +34,11 @@ if (!defined('EMLOG_ROOT')) {
 								<?php blog_author($value['author']) ?>&nbsp;发布于&nbsp;
 								<?= date('Y-n-j', $value['date']) ?>&nbsp;
 								<span class="mh"><?= date('H:i', $value['date']) ?></span>
-								<?php editflg($value['logid'], $value['author']) ?>
 							</div>
 							<div class="log-count">
 								<a href="<?= $value['log_url'] ?>#comments">评论(<?= $value['comnum'] ?>)&nbsp;</a>
 								<a href="<?= $value['log_url'] ?>">浏览(<?= $value['views'] ?>)</a>
+								<span class="loglist-article-edit"><?php editflg($value['logid'], $value['author']) ?></span>
 							</div>
 						</div>
 					</div>

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -423,18 +423,18 @@ function blog_comments($comments) {
 		?>
 		<div class="comment" id="<?= $comment['cid'] ?>">
 			<?php if ($isGravatar == 'y'): ?>
-				<div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>"/></div>
+				<div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>" alt="<?= $comment['poster'] ?> avatar" /></div>
 				<div class="comment-infos">
 					<div class="arrow"></div>
 					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
 					<div class="comment-content"><?= $comment['content'] ?></div>
-					<div class="comment-reply"><a class="com-reply">回复</a></div>
+					<div class="comment-reply"><button class="com-reply comment-replay-btn">回复</button></div>
 				</div>
 			<?php else: ?>
 				<div class="comment-infos-unGravatar">
 					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
 					<div class="comment-content"><?= $comment['content'] ?></div>
-					<div class="comment-reply"><a class="com-reply">回复</a></div>
+					<div class="comment-reply"><button class="com-reply comment-replay-btn">回复</button></div>
 				</div>
 			<?php endif ?>
 			<?php blog_comments_children($comments, $comment['children']) ?>
@@ -462,7 +462,7 @@ function blog_comments_children($comments, $children) {
 					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
 					<div class="comment-content"><?= $comment['content'] ?></div>
 					<?php if ($comment['level'] < 4): ?>
-						<div class="comment-reply"><a class="com-reply">回复</a>
+						<div class="comment-reply"><button class="com-reply comment-replay-btn">回复</button>
 						</div><?php endif ?>
 				</div>
 			<?php else: ?>
@@ -470,7 +470,7 @@ function blog_comments_children($comments, $children) {
 					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
 					<div class="comment-content"><?= $comment['content'] ?></div>
 					<?php if ($comment['level'] < 4): ?>
-						<div class="comment-reply"><a class="com-reply">回复</a>
+						<div class="comment-reply"><button class="com-reply comment-replay-btn">回复</button>
 						</div><?php endif ?>
 				</div>
 			<?php endif ?>
@@ -487,7 +487,7 @@ function blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allo
 	if ($allow_remark == 'y'): ?>
 		<div id="comment-place">
 			<div class="comment-post" id="comment-post">
-				<div class="cancel-reply" id="cancel-reply" style="display:none"><a>取消回复</a></div>
+				<div class="cancel-reply" id="cancel-reply" style="display:none"><button class="comment-replay-btn">取消回复</button></div>
 				<form class="commentform" method="post" name="commentform" action="<?= BLOG_URL ?>index.php?action=addcom" id="commentform"
 					  is-chinese="<?= $isNeedChinese ?>">
 					<input type="hidden" name="gid" value="<?= $logid ?>"/>


### PR DESCRIPTION
1.  文章列出页的「编辑」，在移动端显示可能会因换行而不美观。所以放在右面的浏览量后了。
2. 把评论区头像的 alt 加上了、把回复、取消回复 这些由 < a > 换成了 < button >