### PR TITLE
fix:删去一些异常代码、修复若干前几天引入的 BUG

### DIFF
--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -1458,6 +1458,7 @@ img.zoom-img {
 		/* 磨砂效果 */
 		background: rgba(237, 237, 237, 0.8);
 		backdrop-filter: blur(2px);
+		/* 兼容 Safari 磨砂效果 */
 		-webkit-backdrop-filter: blur(2px);
 		/* 始终固定位置 */
 		z-index: 2;

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -796,8 +796,8 @@ body {
 /* 评论区的 回复、取消回复 按钮 */
 .comment-replay-btn {
 	border: none;
-    cursor: pointer;
-    padding: 0;
+	cursor: pointer;
+	padding: 0;
 	background-color: unset
 }
 .comment-replay-btn:hover {

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -654,7 +654,6 @@ body {
 .comment-post .cancel-reply {
 	float: right;
 	cursor: pointer;
-	_cursor: hand;
 	padding-right: 10%
 }
 .comment-post .cancel-reply:hover {
@@ -797,8 +796,8 @@ body {
 /* 评论区的 回复、取消回复 按钮 */
 .comment-replay-btn {
 	border: none;
-	cursor: pointer;
-	padding: 0;
+    cursor: pointer;
+    padding: 0;
 	background-color: unset
 }
 .comment-replay-btn:hover {
@@ -1128,16 +1127,14 @@ body {
 ---------------------------------------------------*/
 .footinfo {
 	line-height: 2;
-	padding-block: 10px;
+	padding-block: 20px;
 	text-align: center !important;
 }
 
 /* 图片放大
 ---------------------------------------------------*/
 img[data-action="zoom"] {
-	cursor: pointer;
-	cursor: -webkit-zoom-in;
-	cursor: -moz-zoom-in;
+	cursor: zoom-in
   }
 .zoom-img,
 .zoom-img-wrap {
@@ -1148,9 +1145,7 @@ img[data-action="zoom"] {
 			transition: all 300ms;
   }
 img.zoom-img {
-	cursor: pointer;
-	cursor: -webkit-zoom-out;
-	cursor: -moz-zoom-out;
+	cursor: zoom-out
   }
 .zoom-overlay {
 	z-index: 420;
@@ -1463,6 +1458,7 @@ img.zoom-img {
 		/* 磨砂效果 */
 		background: rgba(237, 237, 237, 0.8);
 		backdrop-filter: blur(2px);
+		-webkit-backdrop-filter: blur(2px);
 		/* 始终固定位置 */
 		z-index: 2;
 		position: fixed!important;
@@ -1472,13 +1468,5 @@ img.zoom-img {
 		color: rgb(189, 189, 189);
 		font-size: 10px;
 		padding-left: 10px;
-	}
-	/* toc 在 iPhone 等苹果设备上的磨砂效果  */
-	@supports ((-webkit-backdrop-filter: saturate(180%) blur(20px)) or(backdrop-filter: saturate(180%) blur(20px))) {
-		.toc-con {
-			background: rgba(237, 237, 237, 0.8);
-			-webkit-backdrop-filter: saturate(180%) blur(2px);
-			backdrop-filter: blur(2px);
-		}
 	}
 }

--- a/content/templates/default/log_list.php
+++ b/content/templates/default/log_list.php
@@ -34,11 +34,11 @@ if (!defined('EMLOG_ROOT')) {
 								<?php blog_author($value['author']) ?>&nbsp;发布于&nbsp;
 								<?= date('Y-n-j', $value['date']) ?>&nbsp;
 								<span class="mh"><?= date('H:i', $value['date']) ?></span>
+								<span class="mh"><?php editflg($value['logid'], $value['author']) ?></span>
 							</div>
 							<div class="log-count">
 								<a href="<?= $value['log_url'] ?>#comments">评论(<?= $value['comnum'] ?>)&nbsp;</a>
 								<a href="<?= $value['log_url'] ?>">浏览(<?= $value['views'] ?>)</a>
-								<span class="loglist-article-edit"><?php editflg($value['logid'], $value['author']) ?></span>
 							</div>
 						</div>
 					</div>

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -423,7 +423,7 @@ function blog_comments($comments) {
 		?>
 		<div class="comment" id="<?= $comment['cid'] ?>">
 			<?php if ($isGravatar == 'y'): ?>
-				<div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>" alt="<?= $comment['poster'] ?> avatar" /></div>
+				<div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>" alt="avatar" /></div>
 				<div class="comment-infos">
 					<div class="arrow"></div>
 					<b><?= $comment['poster'] ?> </b><span class="comment-time"><?= $comment['date'] ?></span>
@@ -454,7 +454,7 @@ function blog_comments_children($comments, $children) {
 		$comment = $comments[$child];
 		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
 		?>
-		<div class="comment comment-children" id="comment-<?= $comment['cid'] ?>">
+		<div class="comment comment-children" id="<?= $comment['cid'] ?>">
 			<?php if ($isGravatar == 'y'): ?>
 				<div class="avatar"><img src="<?= getGravatar($comment['mail']) ?>" alt="commentator"/></div>
 				<div class="comment-infos">


### PR DESCRIPTION
1. 删掉一些在一些编译器出现异常的 CSS
2. 修复了前几日引入的一些前端致命 BUG (评论头像、文章列出页的「编辑」显示异常等)

文章列出页的「编辑」，还是决定放到左边，而且直接在移动页面隐藏。因为在移动端的下面的文章 info 实在空间太小了。而且移动端对这个的必要性不大，因为手机浏览器没有很清晰的标签页概念。