### PR TITLE
feat:为系统头像函数添加轮流接管式钩子，方便「插件」对「评论区头像」进行控制

### DIFF
--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -1,5 +1,5 @@
 /**
- * 模版样式表
+ * 模板样式表
  */
 
 /* 全局样式
@@ -1220,6 +1220,7 @@ img.zoom-img {
 /* 「归档」的样式 
 ---------------------------------------------------*/
 .archive {
+	color: #929292;
 	font-size: 16px;
 	padding: 4px;
 	border-color: #ced4da
@@ -1235,7 +1236,7 @@ img.zoom-img {
 ---------------------------------------------------*/
 @media all and (max-width: 1200px) and (min-width: 992px) {
 
-	/* 方便在中、小屏幕隐藏元素的class */
+	/* mh 是方便在中、小屏幕隐藏元素的 class */
 	.mh {
 		display: none
 	}
@@ -1265,7 +1266,7 @@ img.zoom-img {
 		margin: -2px;
 		padding-left: 2px
 	}
-	/* 方便在中、小屏幕隐藏元素的 class */
+	/* mh 是方便在中、小屏幕隐藏元素的 class */
 	.mh {
 		display: none
 	}

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -33,7 +33,8 @@ var myBlog = {
 				.removeAttr("href")
 		}
 		$("#commentform").attr("onsubmit", "return myBlog.comSubmitTip()")  // 评论提交在表单验证未通过的情况下是不能提交的
-	}, /**
+	},
+	/**
 	* 回复
 	*/
 	comReply: function ($t) {
@@ -46,7 +47,8 @@ var myBlog = {
 		$("#comment-pid").attr("value", getpid)
 		$("#cancel-reply").css("display", "unset")
 		$("#comment-place").toggleClass("com-bottom")
-	}, /**
+	},
+	/**
 	* 取消回复
 	*/
 	cancelReply: function ($t) {
@@ -54,7 +56,8 @@ var myBlog = {
 		$("#cancel-reply").css("display", "none")
 		$("#comment-place").append($("#comment-post"))
 			.toggleClass("com-bottom")
-	}, /**
+	},
+	/**
 	* 手机点击展开导航按钮
 	*/
 	navToggle: function ($t) {
@@ -67,7 +70,8 @@ var myBlog = {
 
 		$nav_c.animate({height: nav_height + 'px'}, time, effect)
 		$navbar.slideToggle(time, effect)
-	}, /**
+	},
+	/**
 	* 定位大屏状态下的导航下拉框位置
 	*/
 	calMargin: function ($t) {
@@ -80,7 +84,8 @@ var myBlog = {
 
 		$childMenu.css("width", menuWidth + "px")
 			.css("margin-left", count)
-	}, /**
+	},
+	/**
 	* 提交评论前对表单的验证
 	*/
 	comTip: '', comSubmitTip: function (value) {
@@ -111,7 +116,8 @@ var myBlog = {
 				return true
 			}
 		}
-	}, /**
+	},
+	/**
 	* 显示(隐藏)验证码模态窗
 	*/
 	viewModal: function () {
@@ -122,7 +128,8 @@ var myBlog = {
 		$('body,html').toggleClass('scroll-fix')
 		$modal.fadeToggle()
 		$("input[name='imgcode']").attr("autocomplete", "off")
-	}, /**
+	},
+	/**
 	* 点击刷新验证码
 	*/
 	captchaRefresh: function ($t) {
@@ -130,19 +137,22 @@ var myBlog = {
 		var blogUrl = $("base").attr("href")
 
 		$t.attr("src", blogUrl + "/include/lib/checkcode.php?" + timestamp)
-	}, /**
+	},
+	/**
 	* 图片在点击时，将略缩图转化为原图
 	*/
 	toggleImgSrc: function ($t) {
 		$t.addClass('zoomFocus')
 		$t.attr('src2', $t.attr('src'))
 		$t.attr('src', $t.parent().attr('sourcesrc'))
-	}, /**
+	},
+	/**
 	* 归档下拉框的值被改变，跳转到相应日期文章的链接
 	*/
 	jumpLink: function ($t) {
 		$(window).attr("location",$t.val())
-	},/**
+	},
+	/**
 	* toc 效果
 	*
 	* 启用 toc 目录方式: 在文章最开头写上'[toc]'或者'<!--[toc]-->',最好是单独一行
@@ -162,7 +172,8 @@ var myBlog = {
 			myBlog.tocArray[i]['id'] = $tit.text()
 			$tit.attr("id", myBlog.tocArray[i]['id'])
 		}
-	}, /**
+	},
+	/**
 	* toc 分析（toc 效果程序的入口）
 	*/
 	tocAnalyse: function () {
@@ -188,7 +199,8 @@ var myBlog = {
 		this.tocSetArray()
 		this.tocRender()
 		this.tocMobileSet()
-	},/**
+	},
+	/**
 	* toc 目录渲染
 	*/
 	tocRender: function() {

--- a/include/lib/function.base.php
+++ b/include/lib/function.base.php
@@ -661,7 +661,7 @@ if (!function_exists('getGravatar')) {
 	function getGravatar($email, $s = 40) {
 		$hash = md5($email);
 		$gravatar_url = "//cravatar.cn/avatar/$hash?s=$s";
-		doMultiAction('get_Gravatar', $email, $gravatar_url);
+		doOnceAction('get_Gravatar', $email, $gravatar_url);
 
 		return $gravatar_url;
 	}

--- a/include/lib/function.base.php
+++ b/include/lib/function.base.php
@@ -660,8 +660,10 @@ function chImageSize($img, $max_w, $max_h) {
 if (!function_exists('getGravatar')) {
 	function getGravatar($email, $s = 40) {
 		$hash = md5($email);
-//	return "//gravatar.loli.net/avatar/$hash?s=$s";
-		return "//sdn.geekzu.org/avatar/$hash?s=$s";
+		$gravatar_url = "//cravatar.cn/avatar/$hash?s=$s";
+		doMultiAction('get_Gravatar', $email, $gravatar_url);
+
+		return $gravatar_url;
 	}
 }
 
@@ -1199,4 +1201,3 @@ if (!function_exists('get_browse')) {
 		return $br;
 	}
 }
-


### PR DESCRIPTION
核心：
 
- 为系统头像函数添加轮流接管式钩子，方便「插件」对「评论区头像」进行控制
- 将原有的镜像地址更改为 Cravatar.cn，既使头像输出稳定，又方便国内用户进行头像申请与注册

模板：

- 日常修修改改

------------------------------

示例：插件对系统头像的控制方式：

插件中可写如下代码

```php
addAction('get_Gravatar', 'change_gravatar');

function change_gravatar($email, &$gravatar_url) {

	// 在这里写逻辑，更换 qq 啊什么，是不是注册用户什么的.....
	// $email 就是邮箱地址
	// 反正最终让 $gravatar_url 等于自己整理好的地址就行了
	// 比如下面两行代码：
	$hash = md5($email);
	$gravatar_url = "//sdn.geekzu.org/avatar/$hash?s=$s";

	return true;
}
```