### PR TITLE
feat:More powerful paging function

### DIFF
--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -559,7 +559,7 @@ body {
 }
 .pagination a {
 	color: #c0bcbc;
-	padding: 5.5px 10px 3px 10px;
+	padding: 5.5px 10px 6px 10px;
 	background: white;
 	margin: 0 5px;
 	line-height: 3;

--- a/include/lib/common.php
+++ b/include/lib/common.php
@@ -242,24 +242,54 @@ function pagination($count, $perlogs, $page, $url, $anchor = '') {
 	$pnums = @ceil($count / $perlogs);
 	$re = '';
 	$urlHome = preg_replace("|[\?&/][^\./\?&=]*page[=/\-]|", "", $url);
-	for ($i = $page - 5; $i <= $page + 5 && $i <= $pnums; $i++) {
-		if ($i <= 0) {
-			continue;
+
+	$frontContent = '';
+	$paginContent = '';
+	$endContent = '';
+	$circle_a = 1;  
+	$circle_b = $pnums;
+	$neighborNum = 1;
+	$minKey = 4;
+
+	if ($pnums == 1) return $re;
+	if ($page >= 1 && $pnums >= 7) {
+		$frontContent .= " <a href=\"$urlHome$anchor\">1</a> ";
+		$frontContent .= " <em> ... </em> ";
+		$endContent .= " <em> ... </em> ";
+		$endContent .= " <a href=\"$url$pnums$anchor\">$pnums</a> ";
+		if ($pnums >= 12) {
+			$minKey = 7;
+			$neighborNum = 3;
 		}
-		if ($i == $page) {
-			$re .= " <span>$i</span> ";
-		} elseif ($i == 1) {
-			$re .= " <a href=\"$urlHome$anchor\">$i</a> ";
-		} else {
-			$re .= " <a href=\"$url$i$anchor\">$i</a> ";
+		if ($page < $minKey) {
+			$circle_b = $minKey;
+			$frontContent = '';
+		}
+		if ($page > ($pnums - $minKey + 1)) {
+			$circle_a = $pnums - $minKey + 1;
+			$endContent = '';
+		}
+		if($page > ($minKey - 1) && $page < ($pnums - $minKey + 2)){
+			$circle_a = $page - $neighborNum ;
+			$circle_b = $page + $neighborNum ;
+		}
+		if ($page != 1) {
+			$frontContent = " <a href=\"$url".($page - 1)."$anchor\" title=\"Previous Page\">&laquo;</a> ".$frontContent;
+		}
+		if ($page != $pnums) {
+			$endContent .= " <a href=\"$url".($page + 1)."$anchor\" title=\"Next Page\">&raquo;</a> ";
 		}
 	}
-	if ($page > 6)
-		$re = "<a href=\"{$urlHome}$anchor\" title=\"首页\">&laquo;</a><em> ... </em>$re";
-	if ($page + 5 < $pnums)
-		$re .= "<em> ... </em> <a href=\"$url$pnums$anchor\" title=\"尾页\">&raquo;</a>";
-	if ($pnums <= 1)
-		$re = '';
+	for ($i = $circle_a; $i <= $circle_b; $i++) {
+		if ($i == $page) {
+			$paginContent .= " <span>$i</span> ";
+		} elseif ($i == 1) {
+			$paginContent .= " <a href=\"$urlHome$anchor\">$i</a> ";
+		} else {
+			$paginContent .= " <a href=\"$url$i$anchor\">$i</a> ";
+		}
+	}
+	$re = $frontContent . $paginContent . $endContent;
 	return $re;
 }
 


### PR DESCRIPTION
I optimized the emlog core lib paging function. 

If our total page number is less than 7 (2 ~ 6), then it will return all the page links. 

<img width="534" alt="image" src="https://user-images.githubusercontent.com/33373536/212615058-1d37e399-f963-42d6-a9d4-9d8494c7a543.png">

If our total number of pages is less than 12 and more than 6 (7 ~ 11), then it will returns the result as follow.

<img width="585" alt="image" src="https://user-images.githubusercontent.com/33373536/212615118-e98b310f-0f7b-4ceb-b99e-4aa99581dbd1.png">

If our total number of pages is more than 11 (12 ~ + infinity), then it will return the result as follow.

<img width="645" alt="image" src="https://user-images.githubusercontent.com/33373536/212615194-baea2e4d-91bb-4ef6-9572-2a07a1efad9c.png">