### PR TITLE
fix:CSS variable name conflict and make an appropriate name

### DIFF
--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -596,7 +596,7 @@ body {
 		height: 250px
 	}
 }
-#comment {
+#comments {
 	margin-top: 80px;
 }
 .comment-name {
@@ -1418,7 +1418,7 @@ img.zoom-img {
 	.commentform .comment-info {
 		margin-top: -5px
 	}
-	#comment {
+	#comments {
 		margin-bottom: 80px
 	}
 	.com_control {

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -46,7 +46,7 @@ var myBlog = {
 		$ele.append($com_board)
 		$("#comment-pid").attr("value", getpid)
 		$("#cancel-reply").css("display", "unset")
-		$("#comment").toggleClass("com-bottom")
+		$("#comments").toggleClass("com-bottom")
 	},
 	/**
 	* 取消回复
@@ -54,7 +54,7 @@ var myBlog = {
 	cancelReply: function ($t) {
 		$("#comment-pid").attr("value", "0")
 		$("#cancel-reply").css("display", "none")
-		$("#comment").append($("#comment-post"))
+		$("#comments").append($("#comment-post"))
 			.toggleClass("com-bottom")
 	},
 	/**

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -408,7 +408,7 @@ function blog_comments($comments) {
 
 	foreach ($commentStacks as $cid):
 		$comment = $comments[$cid];
-		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
+		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" rel="external nofollow" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
 		?>
         <div class="comment" id="<?= $comment['cid'] ?>">
 			<?php if ($isGravatar == 'y'): ?>
@@ -445,7 +445,7 @@ function blog_comments_children($comments, $children) {
 	$isGravatar = Option::get('isgravatar');
 	foreach ($children as $child):
 		$comment = $comments[$child];
-		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
+		$comment['poster'] = $comment['url'] ? '<a href="' . $comment['url'] . '" rel="external nofollow" target="_blank">' . $comment['poster'] . '</a>' : $comment['poster'];
 		?>
         <div class="comment comment-children" id="<?= $comment['cid'] ?>">
 			<?php if ($isGravatar == 'y'): ?>

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -480,7 +480,7 @@ function blog_comments_children($comments, $children) {
 function blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allow_remark) {
 	$isNeedChinese = Option::get('comment_needchinese');
 	if ($allow_remark == 'y'): ?>
-        <div id="comment">
+        <div id="comments">
             <div class="comment-post" id="comment-post">
                 <div class="cancel-reply" id="cancel-reply" style="display:none">
                     <button class="comment-replay-btn">取消回复</button>
@@ -504,7 +504,7 @@ function blog_comments_post($logid, $ckname, $ckmail, $ckurl, $verifyCode, $allo
 					<?php endif ?>
 
                     <span class="com_submit_p">
-						<input class="btn"<?php if ($verifyCode != "") { ?> type="button" data-toggle="modal" data-target="#myModal"<?php } else { ?> type="submit"<?php } ?>
+						<input class="btn"<?php if ($verifyCode != "") { ?> type="button" data-toggle="modal" data-target="#myModal"<?php } else { ?> type="submit" <?php } ?>
 							   id="comment_submit" value="发布评论" tabindex="6"/>
 					</span>
 					<?php if ($verifyCode != "") { ?>


### PR DESCRIPTION
In my last commit, I fixed an issue with the default template comment area where the ID name "comment-place" was not appropriate. This was because `line 65 in "include/model/comment_model.php"` specifies that if a user clicks the pagination button to view the next page of comments, the URL will have "#comments" appended to it. 