### PR TITLE
fix:Optimized the XML structure of RSS and some other core adjustment

### DIFF
--- a/admin/article.php
+++ b/admin/article.php
@@ -219,7 +219,7 @@ if ($action === 'write') {
     $is_top = '';
     $is_sortop = '';
     $is_allow_remark = 'checked="checked"';
-    $postDate = date('Y-m-d H:i:s');
+    $postDate = date('Y-m-d H:i');
 
     $MediaSort_Model = new MediaSort_Model();
     $mediaSorts = $MediaSort_Model->getSorts();
@@ -241,7 +241,7 @@ if ($action === 'edit') {
 
     $isdraft = $hide == 'y' ? true : false;
     $containertitle = $isdraft ? '编辑草稿' : '编辑文章';
-    $postDate = date('Y-m-d H:i:s', $date);
+    $postDate = date('Y-m-d H:i', $date);
     $sorts = $CACHE->readCache('sort');
 
     //tag

--- a/admin/views/article_write.php
+++ b/admin/views/article_write.php
@@ -77,7 +77,7 @@
                 </div>
                 <div class="form-group">
                     <label>发布时间：<small class="text-muted">（当设置未来的时间点时，文章将在该时间点后定时发布）</small></label>
-                    <input maxlength="200" name="postdate" id="postdate" value="<?= $postDate ?>" class="form-control"/>
+                    <input type="datetime-local" id="postdate" name="postdate" value="<?= $postDate ?>" class="form-control postdate"/>
                 </div>
                 <div class="form-group">
                     <label>链接别名：<small class="text-muted">（用于seo设置 <a href="./setting.php?action=seo">&rarr;</a>）</small></label>

--- a/admin/views/css/css-main.css
+++ b/admin/views/css/css-main.css
@@ -713,3 +713,8 @@ textarea {
 .editormd-fullscreen {
     z-index: 2;
 }
+
+/* Set the time setting button for "postdate" to the appropriate position */
+.postdate {
+    padding-right: calc(100% - 165px)
+}

--- a/content/templates/default/css/style.css
+++ b/content/templates/default/css/style.css
@@ -212,7 +212,7 @@ body {
 .blog-header {
 	margin-bottom: 2.3rem;
 	background-color: var(--conBgcolor);
-	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1) /* 阴影 */
+	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.02)
 }
 .blog-header-c {
 	height: 71.63px;
@@ -330,7 +330,7 @@ body {
 	border-radius: 4px;
 	top: -3000px;
 	margin-bottom: -34px;
-	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1)
+	box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.02)
 }
 .dropdown-menus .list-menu{
 	padding: 6px
@@ -474,10 +474,6 @@ body {
 #calendar {
 	color: #212529
 }
-#calendar a {
-	color: #000;
-	font-weight: bolder
-}
 .calendartop {
 	letter-spacing: 3px;
 	width: 100%;
@@ -498,8 +494,9 @@ body {
 	line-height: 1.6
 }
 .calendar td a:link {
-	color: #886353;
-	text-decoration: none
+	color: #000;
+	font-weight: bolder;    
+	text-decoration: underline
 }
 .calendar td a:hover {
 	color: #886353;
@@ -1189,6 +1186,16 @@ img.zoom-img {
 	width: 300px;
 	position: absolute;
 	top: 200px
+}
+.toc-con .close-toc {
+	color: #dcdcdd;
+    left: 0px;
+    position: absolute;
+	padding-top: 5px;
+}
+.toc-con ul{
+	margin: 0;
+	padding: 0
 }
 .toc-con li{
 	font-size: 14px;

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -216,7 +216,8 @@ var myBlog = {
 			if (data[i]['type'] < minType) minType = data[i]['type']
 		}
 		tocHtml = tocHtml + '<div class="toc-con" style="left:' + padNum + 'px" id="toc-con">'	// 渲染
-		tocHtml = tocHtml + '<div style="height:calc(100vh - 70px);overflow-y:scroll;" ><lu>'
+		tocHtml = tocHtml + '<a href="javascript:void(0);" class="close-toc mh" id="closeToc">x</a>'
+		tocHtml = tocHtml + '<div style="height:calc(100vh - 70px);overflow-y:scroll;" ><ul>'
 		for (var i = 0; i < data.length; i++) {
 			let k = minType
 			let itemType = data[i]['type']
@@ -236,7 +237,7 @@ var myBlog = {
 			tocHtml = tocHtml + isBold[0] + data[i]['content'] + isBold[1] + '</li>'
 			judgeN = itemType
 		}
-		tocHtml = tocHtml + '</lu></div></div>'
+		tocHtml = tocHtml + '</ul></div></div>'
 		$logcon.before(tocHtml)
 
 		function tocSetListen(){  // 批量添加监听事件
@@ -340,7 +341,17 @@ var myBlog = {
 			}
 			e.stopPropagation() 
 		})
+	},
+	/**
+	* 桌面端的 toc 目录关闭
+	*/
+	tocClose: function () {
+		let logLeftMar = parseInt($(".log-con").css('margin-left')) - 150;
+
+		$(".toc-con").toggle()
+		$(".log-con").css("margin-left", logLeftMar + 'px' )
 	}
+
 }
 
 /**
@@ -386,5 +397,9 @@ $(document).ready(function () {
 
 	$("#archive").change(function () {
 		myBlog.jumpLink($(this))
+	}),
+
+	$("#closeToc").click(function () {
+		myBlog.tocClose()
 	})
 })

--- a/rss.php
+++ b/rss.php
@@ -12,9 +12,13 @@ $Log_Model = new Log_Model();
 $articles = $Log_Model->getLogsForRss(Option::get('rss_output_num'));
 
 echo '<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0">
+<rss version="2.0"
+xmlns:dc="http://purl.org/dc/elements/1.1/"
+xmlns:atom="http://www.w3.org/2005/Atom"
+>
 <channel>
 <title><![CDATA[' . Option::get('blogname') . ']]></title> 
+<atom:link href="'.Option::get('blogurl').'rss.php" rel="self" type="application/rss+xml" />
 <description><![CDATA[' . Option::get('bloginfo') . ']]></description>
 <link>' . BLOG_URL . '</link>
 <language>zh-cn</language>
@@ -33,7 +37,7 @@ if (!empty($articles)) {
     <link>$link</link>
     <description><![CDATA[{$abstract}]]></description>
     <pubDate>$pubdate</pubDate>
-    <author>$author</author>
+    <dc:creator>$author</dc:creator>
     <guid>$link</guid>
 </item>
 END;


### PR DESCRIPTION
## core

I optimized the XML structure of RSS. I used https://validator.w3.org/feed/ to validate rss.php and found some issues that required adjustment.

## admin

I found that HTML5 < input type="datetime-local" > is very suitable for the date setting in the article edit page.

## template

The main update is that the toc can now be closed on large screens.

------------

**核心**：根据  https://validator.w3.org/feed/  这个验证器的提示，优化了 RSS 的输出结构。

**后台**：文章编辑页面的日期选择那个表单，变成了 < input type="datetime-local" > 这个 HTML5 表单。很合适。（当然，我把 秒 这个参数掐去了，因为会产生一些 bug。其实发现在别的地方也用不着。）

**模板**：最主要的是，toc 在桌面端可以关闭了。