### PR TITLE
[fix] When editing an article, the resource classification cannot be obtained correctly

### DIFF
--- a/admin/article.php
+++ b/admin/article.php
@@ -260,6 +260,9 @@ if ($action === 'edit') {
     $Media_Model = new Media_Model();
     $medias = $Media_Model->getMedias();
 
+    $MediaSort_Model = new MediaSort_Model();
+    $mediaSorts = $MediaSort_Model->getSorts();
+
     $is_top = $top == 'y' ? 'checked="checked"' : '';
     $is_sortop = $sortop == 'y' ? 'checked="checked"' : '';
     $is_allow_remark = $allow_remark == 'y' ? 'checked="checked"' : '';


### PR DESCRIPTION
修复编辑文章时不能获取资源分类的问题