### PR TITLE
为log_list.php和echo_log.php加入sort taglist authorinfo的变量支持。

### DIFF
--- a/include/model/log_model.php
+++ b/include/model/log_model.php
@@ -139,6 +139,17 @@ class Log_Model {
             return false;
         }
 
+        $Tag_Model = new Tag_Model();
+        $User_Model = new User_Model();
+
+        $tag_names = $Tag_Model->getNamesFromIds(array_map('intval', explode(',',$row['tags'])));
+        foreach ($tag_names as $value) {
+            $row['taglist'][] = [
+                'name' => htmlspecialchars($value),
+                'url' => Url::tag(rawurlencode($value)),
+            ];
+        }
+
         return [
             'log_title'    => htmlspecialchars($row['title']),
             'timestamp'    => $row['date'],
@@ -162,6 +173,12 @@ class Log_Model {
             'template'     => $row['template'],
             'link'         => $row['link'],
             'tags'         => $row['tags'],
+            'sort' => [
+                'name' => $this->getDetail($row['gid'])['sortname'],
+                'url' => $row['sortid']>0 ? Url::sort($row['sortid']) : '',
+            ],
+            'taglist' => $row['taglist'],
+            'authorinfo' => $User_Model->getOneUser($row['author'])+['url'=>Url::author($row['author'])],
         ];
     }
 
@@ -189,6 +206,8 @@ class Log_Model {
         $now = time();
         $sql = "SELECT * FROM $this->table WHERE type='blog' and hide='n' and checked='y' and date<= $now $condition $limit";
         $res = $this->db->query($sql);
+        $Tag_Model = new Tag_Model();
+        $User_Model = new User_Model();
         $logs = [];
         while ($row = $this->db->fetch_array($res)) {
             $row['log_title'] = htmlspecialchars(trim($row['title']));
@@ -204,6 +223,18 @@ class Log_Model {
             $row['attachment'] = '';
             $row['tag'] = '';
             $row['tbcount'] = 0;
+            $row['sort'] = [
+                'name' => $this->getDetail($row['gid'])['sortname'],
+                'url' => $row['sortid']>0 ? Url::sort($row['sortid']) : '',
+            ];
+            $tag_names = $Tag_Model->getNamesFromIds(array_map('intval', explode(',',$row['tags'])));
+            foreach ($tag_names as $value) {
+                $row['taglist'][] = [
+                    'name' => htmlspecialchars($value),
+                    'url' => Url::tag(rawurlencode($value)),
+                ];
+            }
+            $row['authorinfo'] = $User_Model->getOneUser($row['author'])+['url'=>Url::author($row['author'])];
             $logs[] = $row;
         }
         return $logs;


### PR DESCRIPTION
支持在`log_list.php`里使用
```
$value['sort']
$value['taglist']
$value['authorinfo']
```
以及在`echo_log.php`里使用
```
$sort
$taglist
$authorinfo
```
分别输出**分类**、**标签**、**作者信息**。

1. `sort`是一个array，包含`name`（分类名）和`url`（此分类的网址）
2. `taglist`是一个**二维**array，包含该文章所有tag，每个tag下都是一个array，内含`name`（标签名）和`url`（该标签的网址）
3. `authorinfo`是一个array，包含：
- `username`（用户名）
- `nickname`（用户昵称）
- `name_orig`（未进行HTML 转义的昵称）
- `email`（电邮地址）
- `photo`（头像）
- `description`（备注）
- `role`（用户组）
- `ischeck`（内容是否需要管理员审核）
- `state`（用户状态0正常1禁用）
- `ip`（作者ip）
- `url`（查看该作者所有文章的网址）