### PR TITLE
fix: backend responses by adding missing avatars & other minor details.

### DIFF
--- a/admin/views/article_write.php
+++ b/admin/views/article_write.php
@@ -350,6 +350,7 @@
 
     // 离开页面时，如果文章内容已做修改，则询问用户是否离开
     var articleTextRecord;
+    var titleText = $('title').text();
     hooks.addAction("loaded", function () {
         articleTextRecord = $("textarea[name=logcontent]").text();
     });
@@ -360,17 +361,6 @@
         return '离开页面提示';
     }
 
-    // 如果文章内容已做修改，则使网页标题修改为‘已修改’
-    var titleText = $('title').text()
-    hooks.addAction("loaded", function (obj) {
-        obj.config({
-            onchange: function () {
-                if ($("textarea[name=logcontent]").text() == articleTextRecord) return
-                $('title').text('[已修改] ' + titleText);
-            }
-        });
-    });
-
     // 文章编辑界面全局快捷键 Ctrl（Cmd）+ S 保存内容
     document.addEventListener('keydown', function (e) {
         if (e.keyCode == 83 && (navigator.platform.match("Mac") ? e.metaKey : e.ctrlKey)) {
@@ -378,15 +368,6 @@
             autosave(2);
         }
     });
-
-    // Use cookie to decide whether to collapse [More Options]
-    if (Cookies.get('em_advset') === "right") {
-        $("#advset").toggle();
-        icon_mod = "right";
-        $(".icofont-simple-down").attr("class", "icofont-simple-right")
-    } else {
-        $(".icofont-simple-right").attr("class", "icofont-simple-down")
-    }
 
     // 显示插件扩展label
     const postBar = $("#post_bar");

--- a/admin/views/js/common.js
+++ b/admin/views/js/common.js
@@ -230,7 +230,7 @@ function checkform() {
     if (0 == isalias(a)) {
         return true;
     } else {
-        alert("链接别名错误");
+        infoAlert("链接别名错误");
         $("#alias").focus();
         return false;
     }
@@ -252,7 +252,7 @@ function checkalias() {
     }
 }
 
-// act 1：auto save 2：save
+// act 1：Auto save 2：User manually saves
 function autosave(act) {
     const nodeid = "as_logid";
     const timeout = 60000;
@@ -281,10 +281,8 @@ function autosave(act) {
         return;
     }
     // 距离上次保存成功时间小于一秒时不允许手动保存
-    if ((new Date().getTime() - Cookies.get('em_saveLastTime')) < 1000 && act != 1) {
-        alert("请勿频繁操作！");
-        return;
-    }
+    if ((new Date().getTime() - Cookies.get('em_saveLastTime')) < 1000 && act != 1) return;
+
     const $savedf = $("#savedf");
     const btname = $savedf.val();
     $savedf.val("正在保存中...").attr("disabled", "disabled");
@@ -301,6 +299,9 @@ function autosave(act) {
             const tm = (h < 10 ? "0" + h : h) + ":" + (m < 10 ? "0" + m : m);
             $("#save_info").html("保存于：" + tm + " <a href=\"../?post=" + logid + "\" target=\"_blank\">预览文章</a>");
             $('title').text('[保存成功] ' + titleText);
+            setTimeout(function () {
+                $('title').text(titleText);
+            }, 2000);
             articleTextRecord = $("#addlog textarea[name=logcontent]").val(); // 保存成功后，将原文本记录值替换为现在的文本
             Cookies.set('em_saveLastTime', new Date().getTime()); // 把保存成功时间戳记录（或更新）到 cookie 中
             $("#" + nodeid).val(logid);
@@ -326,8 +327,8 @@ function pagesave() {
         }
     });
     let url = "page.php?action=save";
-    if ($("[name='pageid']").attr("value") < 0) return alert("请先保存页面！");
-    if (!$("[name='pagecontent']").html()) return alert("页面内容不能为空！");
+    if ($("[name='pageid']").attr("value") < 0) return infoAlert("请先发布页面！");
+    if (!$("[name='pagecontent']").html()) return infoAlert("页面内容不能为空！");
     $('title').text('[保存中...] ' + pagetitle);
     $.post(url, $("#addlog").serialize(), function (data) {
         $('title').text('[保存成功] ' + pagetitle);
@@ -337,7 +338,7 @@ function pagesave() {
         pageText = $("textarea").text();
     }).fail(function () {
         $('title').text('[保存失败] ' + pagetitle);
-        alert("保存失败！")
+        infoAlert("保存失败！")
     });
 }
 
@@ -369,7 +370,8 @@ var hooks = {
         if (typeof func == 'function') {
             queue[hook].push(func);
         }
-    }, doAction: function (hook, obj) {
+    }, 
+    doAction: function (hook, obj) {
         try {
             for (var i = 0; i < queue[hook].length; i++) {
                 queue[hook][i](obj);
@@ -466,11 +468,11 @@ function imgPasteExpand(thisEditor) {
                         replaceByNum(`[![](${image.media_icon})](${image.media_url})`, 10);  // 这里的数字 10 对应着’上传中...100%‘是10个字符
                     } else {
                         console.log('获取结果失败！')
-                        alert('获取结果失败！');
+                        infoAlert('获取结果失败！');
                     }
                 })
             }, error: function (result) {
-                alert('上传失败,图片类型错误或网络错误');
+                infoAlert('上传失败,图片类型错误或网络错误');
                 replaceByNum('上传失败,图片类型错误或网络错误', 6);
             }
         })

--- a/admin/views/uc_header.php
+++ b/admin/views/uc_header.php
@@ -31,7 +31,7 @@
     <div class="d-flex flex-column flex-md-row align-items-center p-3 px-md-4 mb-3 border-bottom shadow-sm" id="top-bar">
         <h4 class="my-0 mr-md-5 font-weight-normal"><a href="./" class="text-dark"><?= subString(Option::get('blogname'), 0, 12) ?></a></h4>
         <nav class="my-2 my-md-0 mr-md-auto">
-            <a class="p-2 text-dark" href="/">首页</a>
+            <a class="p-2 text-dark" href="<?= BLOG_URL ?>">首页</a>
             <a class="p-2 text-dark" href="./">个人中心</a>
             <a class="p-2 text-dark" href="article.php"><?= Option::get("posts_name") ?></a>
             <a class="p-2 text-dark" href="media.php">图文</a>

--- a/content/templates/default/css/markdown.css
+++ b/content/templates/default/css/markdown.css
@@ -2,7 +2,7 @@
  * markdown 输出样式
  */
 
-.markdown {
+ .markdown {
     overflow-wrap: break-word;
     text-align: justify
 }
@@ -142,7 +142,7 @@
     background: #f6f6f6;
     border-radius: 3px;
     font-size: 14px;
-    padding: 4px 4px 4px 0px;
+    padding: 4px 4px 4px 4px;
     margin-right: 4px;
 }
 

--- a/content/templates/default/js/common_tpl.js
+++ b/content/templates/default/js/common_tpl.js
@@ -1,7 +1,7 @@
 "use strict"
 
 /**
- * jqurey添加动画扩展。先加速度至配速的50%，再减速到零
+ * jqurey 的动画扩展“缓进缓出”
  */
 jQuery.extend(jQuery.easing, {
     easeInOut: function (x, t, b, c, d) {
@@ -16,7 +16,7 @@ var myBlog = {
      */
     init: function () {
         this.tocAnalyse()  // toc目录生成
-        if ($("#comment-info").length == 0) {  // 大屏幕登录状态，评论框下两角变圆角
+        if ($("#comment-info").length === 0) {  // 大屏幕登录状态，评论框下两角变圆角
             $(".commentform #comment").css("height", "140px")
                 .css('border-radius', '10px')
         }
@@ -24,7 +24,7 @@ var myBlog = {
             let $this = $(".markdown img:eq(" + num + ")")
             let sourceSrc = $(".markdown img:eq(" + num + ")").parent().attr('href')
 
-            if (typeof sourceSrc == "undefined" || sourceSrc.match(/\.(jpeg|jpg|gif|png)$/i) == null) {
+            if (typeof sourceSrc === "undefined" || sourceSrc.match(/\.(jpeg|jpg|gif|png)$/i) === null) {
                 continue
             }
 
@@ -64,7 +64,7 @@ var myBlog = {
         effect = 'easeInOut'
         $navbar = $("#navbarResponsive")
         $nav_c = $(".blog-header-c")
-        nav_height = ($nav_c.height() == 74) ? $navbar.height() + 74 : 74
+        nav_height = ($nav_c.height() === 74) ? $navbar.height() + 74 : 74
 
         $nav_c.animate({height: nav_height + 'px'}, time, effect)
         $navbar.slideToggle(time, effect)
@@ -87,7 +87,7 @@ var myBlog = {
      * 提交评论前对表单的验证
      */
     comTip: '', comSubmitTip: function (value) {
-        if (value == 'judge') {
+        if (value === 'judge') {
             let cnReg = /[\u4e00-\u9fa5]/
             let mailReg = /^[a-z0-9]+([._\\-]*[a-z0-9])*@([a-z0-9]+[-a-z0-9]*[a-z0-9]+.){1,63}[a-z0-9]+$/
             let urlReg = /[^\s]*\.+[^\s]/
@@ -97,18 +97,18 @@ var myBlog = {
             let mail = $('#info_m').val()
             let url = $('#info_u').val()
 
-            if (isCn == 'y' && !cnReg.test(comContent)) {
+            if (isCn === 'y' && !cnReg.test(comContent)) {
                 this.comTip = "评论内容需要包含中文！"
-            } else if (typeof mail !== "undefined" && mail != '' && !mailReg.test(mail)) {
+            } else if (typeof mail !== "undefined" && mail !==  '' && !mailReg.test(mail)) {
                 this.comTip = "邮箱格式错误！"
-            } else if (typeof url !== "undefined" && url != '' && !urlReg.test(url)) {
+            } else if (typeof url !== "undefined" && url !==  '' && !urlReg.test(url)) {
                 this.comTip = "网址格式错误！"
             } else {
                 this.comTip = ''
             }
         } else {
-            if (this.comTip != '') {
-                alert(this.comTip)
+            if (this.comTip !==  '') {
+                infoAlert(this.comTip)
                 return false
             } else {
                 return true
@@ -177,7 +177,7 @@ var myBlog = {
     tocAnalyse: function () {
         var tocFlag = document.querySelector("#emlogEchoLog p")
 
-        if ($("#emlogEchoLog").length == 0) return  // 不在阅读页面  退出
+        if ($("#emlogEchoLog").length === 0) return  // 不在阅读页面  退出
         if (!this.tocFlag.test($('#emlogEchoLog').html().substring(0, 30))) return  // 未声明 toc 标签，退出
         tocFlag.innerHTML = tocFlag.innerHTML.replace(this.tocFlag, "")  // 去除 toc 声明
 
@@ -222,9 +222,9 @@ var myBlog = {
             let isPadding = ''
             let isBold = ['', '']
 
-            if (itemType != judgeN) isPadding = 'style="padding-top:' + chilPad + 'px"'
+            if (itemType !==  judgeN) isPadding = 'style="padding-top:' + chilPad + 'px"'
             tocHtml = tocHtml + '<li ' + isPadding + ' id="to' + i + '" title="' + data[i]['content'] + '" >'
-            if (itemType == minType) {
+            if (itemType === minType) {
                 isBold[0] = '<b>'
                 isBold[1] = '</b>'
             }
@@ -334,7 +334,7 @@ var myBlog = {
         }),
 
             $("html").click(function (e) {
-                if ($(".toc-con") && $(".toc-con").css("display") == "block") {
+                if ($(".toc-con") && $(".toc-con").css("display") === "block") {
                     $(".toc-con").hide()
                 }
                 e.stopPropagation()

--- a/content/templates/default/module.php
+++ b/content/templates/default/module.php
@@ -333,7 +333,7 @@ function blog_navi() {
                         </ul>
                     <?php endif ?>
                     <?php if (!empty($value['childnavi'])) : ?>
-                        <a class='nav-link has-down' id="nav_link" <?= $newtab ?> ><?= $value['naviname'] ?></a>
+                        <a class='nav-link has-down' id="nav_link" href="<?= $value['url'] ?>" <?= $newtab ?> ><?= $value['naviname'] ?></a>
                         <ul class="dropdown-menus">
                             <?php foreach ($value['childnavi'] as $row) {
                                 $newtab = $row['newtab'] == 'y' ? 'target="_blank"' : '';

--- a/include/model/comment_model.php
+++ b/include/model/comment_model.php
@@ -213,12 +213,13 @@ class Comment_Model {
         }
 
         $name = addslashes($user_info['name_orig']);
+        $mail = addslashes($user_info['email']);
         $uid = UID;
         $ipaddr = getIp();
         $timestamp = time();
         $useragent = addslashes(getUA());
         $this->db->query("INSERT INTO " . DB_PREFIX . "comment (date,poster,uid,gid,comment,mail,url,hide,ip,agent,pid)
-                    VALUES ('$timestamp','$name',$uid,$blogId,'$content','','','$hide','$ipaddr','$useragent',$pid)");
+                    VALUES ('$timestamp','$name',$uid,$blogId,'$content','$mail','','$hide','$ipaddr','$useragent',$pid)");
         $this->updateCommentNum($blogId);
     }
 


### PR DESCRIPTION
后台：

1. 将一些提示框改为了 layui 的提示框，删除一些无用的 js
2. 普通用户的后台的左上的「首页」链接，改成了 `<?= BLOG_URL ?>`，因为会有些人不在根目录安装 emlog
3. 后台回复评论，使用的是 coment_modal 里的 replyComment() ，但是很奇怪，里面不传入 邮箱地址，这导致前台无法显示头像。

（另外，开始评论审核模式时，后台普通用户在回复其他人的评论时，不会进入审核阶段，这和前台普通用户回复评论的结果是不一样的，不知这是 feat 还是 bug？）

模板：

1. 主要是将多年的 bug 给修了下，此后 有下拉框（子链接）的自定义的链接，可以点击了。
2. 一些简单的代码调整

--------

Backend:

1. Converted some prompts to Layui's prompts and removed some unused JavaScript files.
2. Changed the "Home" link in the upper left corner of the backend for regular users to `<?= BLOG_URL ?>`, as some people did not install emlog in the root directory.
3. When replying to comments in the backend, it uses the replyComment() function from coment_modal, but strangely, it does not pass in the email address, which leads to the inability to display avatars on the frontend.
(Additionally, when starting the moderation mode, regular users in the backend do not enter the moderation stage when replying to other people's comments, which is different from the result of regular users replying to comments on the frontend. I'm not sure if this is a feature or a bug.)

Template:

1. Primarily fixed some bugs that had been present for years, after which, clickable custom links with dropdowns (sublinks) work as expected.
2. Made some simple code adjustments.