### PR TITLE
在写页面或编辑页面的时候，可以给页面增加标签

### DIFF
--- a/admin/page.php
+++ b/admin/page.php
@@ -11,6 +11,7 @@
  */
 
 require_once 'globals.php';
+$Tag_Model = new Tag_Model();
 
 if (empty($action)) {
     $emPage = new Log_Model();
@@ -48,6 +49,8 @@ if ($action == 'new') {
 
     $MediaSort_Model = new MediaSort_Model();
     $mediaSorts = $MediaSort_Model->getSorts();
+    $tagStr = '';
+    $tags = $Tag_Model->getTags();
 
     $Template_Model = new Template_Model();
     $customTemplates = $Template_Model->getCustomTemplates('page');
@@ -76,6 +79,15 @@ if ($action == 'mod') {
     $MediaSort_Model = new MediaSort_Model();
     $mediaSorts = $MediaSort_Model->getSorts();
 
+    //tag
+    $tags = [];
+    foreach ($Tag_Model->getTag($pageId) as $val) {
+        $tags[] = $val['tagname'];
+    }
+    $tagStr = implode(',', $tags);
+    //old tag
+    $tags = $Tag_Model->getTags();
+
     $is_allow_remark = $allow_remark == 'y' ? 'checked="checked"' : '';
     $is_home_page = Option::get('home_page_id') == $pageId ? 'checked="checked"' : '';
 
@@ -99,6 +111,7 @@ if ($action == 'save') {
     $home_page = isset($_POST['home_page']) ? addslashes(trim($_POST['home_page'])) : 'n';
     $link = Input::postStrVar('link');
     $cover = Input::postStrVar('cover');
+    $tagstring = isset($_POST['tag']) ? strip_tags(addslashes(trim($_POST['tag']))) : '';
 
     $postTime = time();
 
@@ -125,9 +138,11 @@ if ($action == 'save') {
     if ($pageId > 0) {
         $emPage->updateLog($logData, $pageId);
         $directUrl = './page.php?active_pubpage=1';
+        $Tag_Model->updateTag($tagstring, $pageId);
     } else {
         $pageId = $emPage->addlog($logData);
         $directUrl = './page.php?active_hide_n=1';
+        $Tag_Model->addTag($tagstring, $pageId);
     }
 
     if ($home_page === 'y') {

--- a/admin/views/page_create.php
+++ b/admin/views/page_create.php
@@ -52,6 +52,21 @@
                     <small class="text-muted">填写后不展示页面内容，直接跳转该地址</small>
                 </div>
                 <div class="form-group">
+                    <label>标签：</label>
+                    <?php if ($tags): ?>
+                        <span class="small"> <a href="javascript:doToggle('tags', 1);">近期使用的+</a></span>
+                        <div id="tags" class="mb-2" style="display: none">
+                            <?php
+                            foreach ($tags as $val) {
+                                echo " <a class=\"em-badge small em-badge-tag\" href=\"javascript: insertTag('{$val['tagname']}','tag');\">{$val['tagname']}</a> ";
+                            }
+                            ?>
+                        </div>
+                    <?php endif; ?>
+                    <input name="tag" id="tag" class="form-control" value="<?= $tagStr ?>"/>
+                    <small class="text-muted">也用于页面关键词，英文逗号分隔</small>
+                </div>
+                <div class="form-group">
                     <label>页面模板：</label>
                     <?php if ($customTemplates):
                         $sortListHtml = '<option value="">默认</option>';


### PR DESCRIPTION
功能描述以及使用场景：
1. 在写页面或编辑页面的时候，可以给页面增加标签(跟文章标签一致)
2. 标签会显示到页面的keywords元信息(跟文章一致)
3. 模版开发者可根据关键字，在页面调用其它相关文章来推荐文章
4. 模版开发者可根据关键字，将一系列页面聚合在一起（类似"页面分类",小众需求）