### PR TITLE
feat: 头像邮箱使用 sha256 哈希

### DIFF
--- a/include/lib/common.php
+++ b/include/lib/common.php
@@ -631,8 +631,8 @@ function chImageSize($img, $max_w, $max_h) {
  */
 if (!function_exists('getGravatar')) {
     function getGravatar($email, $s = 40) {
-        $hash = md5($email);
-        $gravatar_url = "//cravatar.cn/avatar/$hash?s=$s";
+        $hash = hash('sha256', $email);
+        $gravatar_url = "//weavatar.com/avatar/$hash?s=$s";
         doOnceAction('get_Gravatar', $email, $gravatar_url);
 
         return $gravatar_url;


### PR DESCRIPTION
Gravatar 去年下半年开始支持 sha256 作为邮箱哈希算法并在[文档](https://docs.gravatar.com/api/avatars/hash/)中首选推荐使用 sha256 以增强隐私性。

[Cravatar](https://cravatar.com/developer/creating-the-hash) 服务不支持 sha256 且没有更新计划，此 PR 使用支持 sha256 的 [WeAvatar](https://weavatar.com/doc) 代替。

MD5 头像示例：https://weavatar.com/avatar/44044dae072b8d87ef986e07121c63a4
SHA256 头像示例：https://weavatar.com/avatar/18e77debb1bc0000c0b50757b8f1bebb2c3e4df3d494124f776c15dbc1ebe8a5